### PR TITLE
Support shapes and text boxes

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -933,6 +933,9 @@ export interface ShapeProps {
 	 * See https://learn.microsoft.com/ja-jp/dotnet/api/documentformat.openxml.drawing.shapetypevalues
 	 */
 	type: string;
+	rotation?: number;
+	horizontalFlip?: boolean;
+	verticalFlip?: boolean;
 	fill?: ShapeFill;
 	outline?: ShapeOutline;
 	textBody?: ShapeTextBody;

--- a/index.d.ts
+++ b/index.d.ts
@@ -974,6 +974,7 @@ export type ShapeRun = {
 
 export type ShapeRunFont = {
 	size: number,
+	color: { theme?: string, rgb?: string },
 	bold: boolean,
 	italic: boolean,
 	underline: 'sng' | 'dbl' | 'none',

--- a/index.d.ts
+++ b/index.d.ts
@@ -912,12 +912,12 @@ export class Anchor implements IAnchor {
 
 	constructor(model?: IAnchor | object);
 }
-export interface ImageRange {
+export interface DrawingRange {
 	tl: Anchor;
 	br: Anchor;
 }
 
-export interface ImagePosition {
+export interface DrawingPosition {
 	tl: { col: number; row: number };
 	ext: { width: number; height: number };
 }
@@ -926,6 +926,8 @@ export interface ImageHyperlinkValue {
 	hyperlink: string;
 	tooltip?: string;
 }
+
+export type ShapeType = 'line' | 'rect' | 'roundRect' | 'ellipse' | 'triangle' | 'rightArrow' | 'downArrow' | 'leftBrace' | 'rightBrace';
 
 export interface Range extends Location {
 	sheetName: string;
@@ -1337,13 +1339,20 @@ export interface Worksheet {
 	 * Using the image id from `Workbook.addImage`,
 	 * embed an image within the worksheet to cover a range
 	 */
-	addImage(imageId: number, range: string | { editAs?: string; } & ImageRange & { hyperlinks?: ImageHyperlinkValue } | { editAs?: string; } & ImagePosition & { hyperlinks?: ImageHyperlinkValue }): void;
+	addImage(imageId: number, range: string | { editAs?: string; } & DrawingRange & { hyperlinks?: ImageHyperlinkValue } | { editAs?: string; } & DrawingPosition & { hyperlinks?: ImageHyperlinkValue }): void;
 
 	getImages(): Array<{
 		type: 'image',
-		imageId: string;
-		range: ImageRange;
+		imageId: string,
+		range: DrawingRange,
 	}>;
+
+	addShape(props: {type: ShapeType}, range: string | { editAs?: string; } & DrawingRange | { editAs?: string; } & DrawingPosition ): void;
+
+	getShapes(): Array<{
+		props: {type: ShapeType},
+		range: DrawingRange,
+	}>
 
 	commit(): void;
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -931,6 +931,7 @@ export interface ShapeProps {
 	type: ShapeType;
 	fill?: ShapeFill;
 	outline?: ShapeOutline;
+	textBody?: ShapeTextBody;
 }
 
 export type ShapeType = 'line' | 'rect' | 'roundRect' | 'ellipse' | 'triangle' | 'rightArrow' | 'downArrow' | 'leftBrace' | 'rightBrace';
@@ -954,6 +955,18 @@ export type ShapeOutline = {
 		head?: ShapeArrowEnd,
 		tail?: ShapeArrowEnd
 	}
+}
+
+export type ShapeTextBody = {
+	paragraphs: ShapeParagraph[],
+}
+
+export type ShapeParagraph = {
+	runs: ShapeRun[],
+}
+
+export type ShapeRun = {
+	text: string,
 }
 
 export interface Range extends Location {

--- a/index.d.ts
+++ b/index.d.ts
@@ -959,10 +959,12 @@ export type ShapeOutline = {
 
 export type ShapeTextBody = {
 	paragraphs: ShapeParagraph[],
+	vertAlign?: 't' | 'ctr' | 'b',
 }
 
 export type ShapeParagraph = {
 	runs: ShapeRun[],
+	alignment?: 'l' | 'ctr' | 'r',
 }
 
 export type ShapeRun = {

--- a/index.d.ts
+++ b/index.d.ts
@@ -928,13 +928,15 @@ export interface DrawingHyperlinkValue {
 }
 
 export interface ShapeProps {
-	type: ShapeType;
+	/**
+	 * Defined as DocumentFormat.OpenXml.Drawing.ShapeTypeValues in Open API Spec.
+	 * See https://learn.microsoft.com/ja-jp/dotnet/api/documentformat.openxml.drawing.shapetypevalues
+	 */
+	type: string;
 	fill?: ShapeFill;
 	outline?: ShapeOutline;
 	textBody?: ShapeTextBody;
 }
-
-export type ShapeType = 'line' | 'rect' | 'roundRect' | 'ellipse' | 'triangle' | 'rightArrow' | 'downArrow' | 'leftBrace' | 'rightBrace';
 
 export type ShapeFill = {
 	type: 'solid',

--- a/index.d.ts
+++ b/index.d.ts
@@ -927,7 +927,17 @@ export interface ImageHyperlinkValue {
 	tooltip?: string;
 }
 
+export interface ShapeProps {
+	type: ShapeType;
+	fill: ShapeFill;
+}
+
 export type ShapeType = 'line' | 'rect' | 'roundRect' | 'ellipse' | 'triangle' | 'rightArrow' | 'downArrow' | 'leftBrace' | 'rightBrace';
+
+export type ShapeFill = {
+	type: 'solid',
+	color: { theme?: string }
+}
 
 export interface Range extends Location {
 	sheetName: string;
@@ -1347,10 +1357,10 @@ export interface Worksheet {
 		range: DrawingRange,
 	}>;
 
-	addShape(props: {type: ShapeType}, range: string | { editAs?: string; } & DrawingRange | { editAs?: string; } & DrawingPosition ): void;
+	addShape(props: ShapeProps, range: string | { editAs?: string; } & DrawingRange | { editAs?: string; } & DrawingPosition ): void;
 
 	getShapes(): Array<{
-		props: {type: ShapeType},
+		props: ShapeProps,
 		range: DrawingRange,
 	}>
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -969,6 +969,14 @@ export type ShapeParagraph = {
 
 export type ShapeRun = {
 	text: string,
+	font?: Partial<ShapeRunFont>,
+}
+
+export type ShapeRunFont = {
+	size: number,
+	bold: boolean,
+	italic: boolean,
+	underline: 'sng' | 'dbl' | 'none',
 }
 
 export interface Range extends Location {

--- a/index.d.ts
+++ b/index.d.ts
@@ -929,7 +929,8 @@ export interface ImageHyperlinkValue {
 
 export interface ShapeProps {
 	type: ShapeType;
-	fill: ShapeFill;
+	fill?: ShapeFill;
+	outline?: ShapeOutline;
 }
 
 export type ShapeType = 'line' | 'rect' | 'roundRect' | 'ellipse' | 'triangle' | 'rightArrow' | 'downArrow' | 'leftBrace' | 'rightBrace';
@@ -937,6 +938,11 @@ export type ShapeType = 'line' | 'rect' | 'roundRect' | 'ellipse' | 'triangle' |
 export type ShapeFill = {
 	type: 'solid',
 	color: { theme?: string, rgb?: string }
+}
+
+export type ShapeOutline = {
+	weight?: number,
+	color?: { theme?: string, rgb?: string }
 }
 
 export interface Range extends Location {

--- a/index.d.ts
+++ b/index.d.ts
@@ -922,7 +922,7 @@ export interface DrawingPosition {
 	ext: { width: number; height: number };
 }
 
-export interface ImageHyperlinkValue {
+export interface DrawingHyperlinkValue {
 	hyperlink: string;
 	tooltip?: string;
 }
@@ -1390,7 +1390,7 @@ export interface Worksheet {
 	 * Using the image id from `Workbook.addImage`,
 	 * embed an image within the worksheet to cover a range
 	 */
-	addImage(imageId: number, range: string | { editAs?: string; } & DrawingRange & { hyperlinks?: ImageHyperlinkValue } | { editAs?: string; } & DrawingPosition & { hyperlinks?: ImageHyperlinkValue }): void;
+	addImage(imageId: number, range: string | { editAs?: string; } & DrawingRange & { hyperlinks?: DrawingHyperlinkValue } | { editAs?: string; } & DrawingPosition & { hyperlinks?: DrawingHyperlinkValue }): void;
 
 	getImages(): Array<{
 		type: 'image',
@@ -1398,7 +1398,7 @@ export interface Worksheet {
 		range: DrawingRange,
 	}>;
 
-	addShape(props: ShapeProps, range: string | { editAs?: string; } & DrawingRange | { editAs?: string; } & DrawingPosition ): void;
+	addShape(props: ShapeProps, range: string | { editAs?: string; } & DrawingRange | { editAs?: string; } & DrawingPosition, hyperlinks?: DrawingHyperlinkValue ): void;
 
 	getShapes(): Array<{
 		props: ShapeProps,

--- a/index.d.ts
+++ b/index.d.ts
@@ -936,7 +936,7 @@ export type ShapeType = 'line' | 'rect' | 'roundRect' | 'ellipse' | 'triangle' |
 
 export type ShapeFill = {
 	type: 'solid',
-	color: { theme?: string }
+	color: { theme?: string, rgb?: string }
 }
 
 export interface Range extends Location {

--- a/index.d.ts
+++ b/index.d.ts
@@ -940,9 +940,20 @@ export type ShapeFill = {
 	color: { theme?: string, rgb?: string }
 }
 
+export interface ShapeArrowEnd {
+	type?: 'triangle' | 'arrow' | 'stealth' | 'diamond' | 'oval';
+	length?: 'lg' | 'med' | 'sm';
+	width?: 'lg' | 'med' | 'sm';
+}
+
 export type ShapeOutline = {
 	weight?: number,
-	color?: { theme?: string, rgb?: string }
+	color?: { theme?: string, rgb?: string },
+	dash?: 'solid' | 'sysDot' | 'sysDash' | 'dash' | 'dashDot' | 'lgDash' | 'lgDashDot' | 'lgDashDotDot',
+	arrow?: {
+		head?: ShapeArrowEnd,
+		tail?: ShapeArrowEnd
+	}
 }
 
 export interface Range extends Location {

--- a/lib/doc/drawing-range.js
+++ b/lib/doc/drawing-range.js
@@ -1,0 +1,22 @@
+const colCache = require('../utils/col-cache');
+const Anchor = require('./anchor');
+
+module.exports = {
+  parseRange: (range, hyperlinks, worksheet) => {
+    if (typeof range === 'string') {
+      const decoded = colCache.decode(range);
+      return {
+        tl: new Anchor(worksheet, {col: decoded.left, row: decoded.top}, -1),
+        br: new Anchor(worksheet, {col: decoded.right, row: decoded.bottom}, 0),
+        editAs: 'oneCell',
+      };
+    }
+    return {
+      tl: new Anchor(worksheet, range.tl, 0),
+      br: range.br && new Anchor(worksheet, range.br, 0),
+      ext: range.ext,
+      editAs: range.editAs,
+      hyperlinks: hyperlinks || range.hyperlinks,
+    };
+  },
+};

--- a/lib/doc/image.js
+++ b/lib/doc/image.js
@@ -1,5 +1,4 @@
-const colCache = require('../utils/col-cache');
-const Anchor = require('./anchor');
+const {parseRange} = require('./drawing-range');
 
 class Image {
   constructor(worksheet, model) {
@@ -36,22 +35,7 @@ class Image {
     this.imageId = imageId;
 
     if (type === 'image') {
-      if (typeof range === 'string') {
-        const decoded = colCache.decode(range);
-        this.range = {
-          tl: new Anchor(this.worksheet, {col: decoded.left, row: decoded.top}, -1),
-          br: new Anchor(this.worksheet, {col: decoded.right, row: decoded.bottom}, 0),
-          editAs: 'oneCell',
-        };
-      } else {
-        this.range = {
-          tl: new Anchor(this.worksheet, range.tl, 0),
-          br: range.br && new Anchor(this.worksheet, range.br, 0),
-          ext: range.ext,
-          editAs: range.editAs,
-          hyperlinks: hyperlinks || range.hyperlinks,
-        };
-      }
+      this.range = parseRange(range, hyperlinks, this.worksheet);
     }
   }
 }

--- a/lib/doc/shape.js
+++ b/lib/doc/shape.js
@@ -8,7 +8,12 @@ class Shape {
 
   get model() {
     return {
-      props: this.props,
+      props: {
+        type: this.props.type,
+        fill: this.props.fill,
+        outline: this.props.outline,
+        textBody: this.props.textBody,
+      },
       range: {
         tl: this.range.tl.model,
         br: this.range.br && this.range.br.model,
@@ -19,9 +24,59 @@ class Shape {
   }
 
   set model({props, range}) {
-    this.props = props;
+    this.props = {type: props.type};
+    if (props.fill) {
+      this.props.fill = props.fill;
+    }
+    if (props.outline) {
+      this.props.outline = props.outline;
+    }
+    if (props.textBody) {
+      this.props.textBody = parseAsTextBody(props.textBody);
+    }
     this.range = parseRange(range, undefined, this.worksheet);
   }
+}
+
+function parseAsTextBody(input) {
+  if (typeof input === 'string') {
+    return {
+      paragraphs: [parseAsParagraph(input)],
+    };
+  }
+  if (Array.isArray(input)) {
+    return {
+      paragraphs: input.map(parseAsParagraph),
+    };
+  }
+  return {
+    paragraphs: input.paragraphs.map(parseAsParagraph),
+  };
+}
+
+function parseAsParagraph(input) {
+  if (typeof input === 'string') {
+    return {
+      runs: [parseAsRun(input)],
+    };
+  }
+  if (Array.isArray(input)) {
+    return {
+      runs: input.map(parseAsRun),
+    };
+  }
+  return {
+    runs: input.runs.map(parseAsRun),
+  };
+}
+
+function parseAsRun(input) {
+  if (typeof input === 'string') {
+    return {
+      text: input,
+    };
+  }
+  return input;
 }
 
 // DocumentFormat.OpenXml.Drawing.ShapeTypeValues

--- a/lib/doc/shape.js
+++ b/lib/doc/shape.js
@@ -84,7 +84,13 @@ function parseAsRun(input) {
       text: input,
     };
   }
-  return input;
+  const model = {
+    text: input.text,
+  };
+  if (input.font) {
+    model.font = input.font;
+  }
+  return model;
 }
 
 // DocumentFormat.OpenXml.Drawing.ShapeTypeValues

--- a/lib/doc/shape.js
+++ b/lib/doc/shape.js
@@ -1,0 +1,40 @@
+const {parseRange} = require('./drawing-range');
+
+class Shape {
+  constructor(worksheet, model) {
+    this.worksheet = worksheet;
+    this.model = model;
+  }
+
+  get model() {
+    return {
+      props: this.props,
+      range: {
+        tl: this.range.tl.model,
+        br: this.range.br && this.range.br.model,
+        ext: this.range.ext,
+        editAs: this.range.editAs,
+      },
+    };
+  }
+
+  set model({props, range}) {
+    this.props = props;
+    this.range = parseRange(range, undefined, this.worksheet);
+  }
+}
+
+// DocumentFormat.OpenXml.Drawing.ShapeTypeValues
+Shape.Types = {
+  LINE: 'line',
+  RECTANGLE: 'rect',
+  ROUND_RECTANGLE: 'roundRect',
+  ELLIPSE: 'ellipse',
+  TRIANGLE: 'triangle',
+  RIGHT_ARROW: 'rightArrow',
+  DOWN_ARROW: 'downArrow',
+  LEFT_BRACE: 'leftBrace',
+  RIGHT_BRACE: 'rightBrace',
+};
+
+module.exports = Shape;

--- a/lib/doc/shape.js
+++ b/lib/doc/shape.js
@@ -20,10 +20,11 @@ class Shape {
         ext: this.range.ext,
         editAs: this.range.editAs,
       },
+      hyperlinks: this.hyperlinks,
     };
   }
 
-  set model({props, range}) {
+  set model({props, range, hyperlinks}) {
     this.props = {type: props.type};
     if (props.fill) {
       this.props.fill = props.fill;
@@ -35,6 +36,7 @@ class Shape {
       this.props.textBody = parseAsTextBody(props.textBody);
     }
     this.range = parseRange(range, undefined, this.worksheet);
+    this.hyperlinks = hyperlinks;
   }
 }
 

--- a/lib/doc/shape.js
+++ b/lib/doc/shape.js
@@ -10,6 +10,9 @@ class Shape {
     return {
       props: {
         type: this.props.type,
+        rotation: this.props.rotation,
+        horizontalFlip: this.props.horizontalFlip,
+        verticalFlip: this.props.verticalFlip,
         fill: this.props.fill,
         outline: this.props.outline,
         textBody: this.props.textBody,
@@ -26,6 +29,15 @@ class Shape {
 
   set model({props, range, hyperlinks}) {
     this.props = {type: props.type};
+    if (props.rotation) {
+      this.props.rotation = props.rotation;
+    }
+    if (props.horizontalFlip) {
+      this.props.horizontalFlip = props.horizontalFlip;
+    }
+    if (props.verticalFlip) {
+      this.props.verticalFlip = props.verticalFlip;
+    }
     if (props.fill) {
       this.props.fill = props.fill;
     }

--- a/lib/doc/shape.js
+++ b/lib/doc/shape.js
@@ -95,17 +95,4 @@ function parseAsRun(input) {
   return model;
 }
 
-// DocumentFormat.OpenXml.Drawing.ShapeTypeValues
-Shape.Types = {
-  LINE: 'line',
-  RECTANGLE: 'rect',
-  ROUND_RECTANGLE: 'roundRect',
-  ELLIPSE: 'ellipse',
-  TRIANGLE: 'triangle',
-  RIGHT_ARROW: 'rightArrow',
-  DOWN_ARROW: 'downArrow',
-  LEFT_BRACE: 'leftBrace',
-  RIGHT_BRACE: 'rightBrace',
-};
-
 module.exports = Shape;

--- a/lib/doc/shape.js
+++ b/lib/doc/shape.js
@@ -49,9 +49,13 @@ function parseAsTextBody(input) {
       paragraphs: input.map(parseAsParagraph),
     };
   }
-  return {
+  const model = {
     paragraphs: input.paragraphs.map(parseAsParagraph),
   };
+  if (input.vertAlign) {
+    model.vertAlign = input.vertAlign;
+  }
+  return model;
 }
 
 function parseAsParagraph(input) {
@@ -65,9 +69,13 @@ function parseAsParagraph(input) {
       runs: input.map(parseAsRun),
     };
   }
-  return {
+  const model = {
     runs: input.runs.map(parseAsRun),
   };
+  if (input.alignment) {
+    model.alignment = input.alignment;
+  }
+  return model;
 }
 
 function parseAsRun(input) {

--- a/lib/doc/worksheet.js
+++ b/lib/doc/worksheet.js
@@ -757,8 +757,8 @@ class Worksheet {
 
   // =========================================================================
   // Shapes
-  addShape({type}, range) {
-    this.shapes.push(new Shape(this, {type, range}));
+  addShape(props, range) {
+    this.shapes.push(new Shape(this, {props, range}));
   }
 
   getShapes() {

--- a/lib/doc/worksheet.js
+++ b/lib/doc/worksheet.js
@@ -6,6 +6,7 @@ const Row = require('./row');
 const Column = require('./column');
 const Enums = require('./enums');
 const Image = require('./image');
+const Shape = require('./shape');
 const Table = require('./table');
 const DataValidations = require('./data-validations');
 const {makePivotTable} = require('./pivot-table');
@@ -118,6 +119,9 @@ class Worksheet {
 
     // for images, etc
     this._media = [];
+
+    // for shapes
+    this.shapes = [];
 
     // worksheet protection
     this.sheetProtection = null;
@@ -752,6 +756,16 @@ class Worksheet {
   }
 
   // =========================================================================
+  // Shapes
+  addShape({type}, range) {
+    this.shapes.push(new Shape(this, {type, range}));
+  }
+
+  getShapes() {
+    return this.shapes;
+  }
+
+  // =========================================================================
   // Worksheet Protection
   protect(password, options) {
     // TODO: make this function truly async
@@ -872,6 +886,7 @@ Please leave feedback at https://github.com/exceljs/exceljs/discussions/2575`
       views: this.views,
       autoFilter: this.autoFilter,
       media: this._media.map(medium => medium.model),
+      shapes: this.shapes,
       sheetProtection: this.sheetProtection,
       tables: Object.values(this.tables).map(table => table.model),
       pivotTables: this.pivotTables,
@@ -934,6 +949,7 @@ Please leave feedback at https://github.com/exceljs/exceljs/discussions/2575`
     this.views = value.views;
     this.autoFilter = value.autoFilter;
     this._media = value.media.map(medium => new Image(this, medium));
+    this.shapes = value.shapes;
     this.sheetProtection = value.sheetProtection;
     this.tables = value.tables.reduce((tables, table) => {
       const t = new Table();

--- a/lib/doc/worksheet.js
+++ b/lib/doc/worksheet.js
@@ -757,8 +757,8 @@ class Worksheet {
 
   // =========================================================================
   // Shapes
-  addShape(props, range) {
-    this.shapes.push(new Shape(this, {props, range}));
+  addShape(props, range, hyperlinks) {
+    this.shapes.push(new Shape(this, {props, range, hyperlinks}));
   }
 
   getShapes() {

--- a/lib/xlsx/xform/drawing/c-nv-pr-xform.js
+++ b/lib/xlsx/xform/drawing/c-nv-pr-xform.js
@@ -2,9 +2,12 @@ const BaseXform = require('../base-xform');
 const HlickClickXform = require('./hlink-click-xform');
 const ExtLstXform = require('./ext-lst-xform');
 
+// DocumentFormat.OpenXml.Drawing.Spreadsheet.NonVisualDrawingProperties
 class CNvPrXform extends BaseXform {
-  constructor() {
+  constructor(isPicture) {
     super();
+
+    this.isPicture = isPicture;
 
     this.map = {
       'a:hlinkClick': new HlickClickXform(),
@@ -19,7 +22,7 @@ class CNvPrXform extends BaseXform {
   render(xmlStream, model) {
     xmlStream.openNode(this.tag, {
       id: model.index,
-      name: `Picture ${model.index}`,
+      name: `${this.isPicture ? 'Picture' : 'Shape'} ${model.index}`,
     });
     this.map['a:hlinkClick'].render(xmlStream, model);
     this.map['a:extLst'].render(xmlStream, model);

--- a/lib/xlsx/xform/drawing/nv-sp-pr-xform.js
+++ b/lib/xlsx/xform/drawing/nv-sp-pr-xform.js
@@ -1,25 +1,24 @@
 const BaseXform = require('../base-xform');
 const CNvPrXform = require('./c-nv-pr-xform');
-const CNvPicPrXform = require('./c-nv-pic-pr-xform');
 
-class NvPicPrXform extends BaseXform {
+// DocumentFormat.OpenXml.Drawing.Spreadsheet.NonVisualShapeProperties
+class NvSpPrXform extends BaseXform {
   constructor() {
     super();
 
     this.map = {
-      'xdr:cNvPr': new CNvPrXform(true),
-      'xdr:cNvPicPr': new CNvPicPrXform(),
+      'xdr:cNvPr': new CNvPrXform(false),
     };
   }
 
   get tag() {
-    return 'xdr:nvPicPr';
+    return 'xdr:nvSpPr';
   }
 
-  render(xmlStream, model) {
+  render(xmlStream, shape) {
     xmlStream.openNode(this.tag);
-    this.map['xdr:cNvPr'].render(xmlStream, model);
-    this.map['xdr:cNvPicPr'].render(xmlStream, model);
+    this.map['xdr:cNvPr'].render(xmlStream, shape);
+    xmlStream.leafNode('xdr:cNvSpPr');
     xmlStream.closeNode();
   }
 
@@ -31,7 +30,6 @@ class NvPicPrXform extends BaseXform {
 
     switch (node.name) {
       case this.tag:
-        this.reset();
         break;
       default:
         this.parser = this.map[node.name];
@@ -62,4 +60,4 @@ class NvPicPrXform extends BaseXform {
   }
 }
 
-module.exports = NvPicPrXform;
+module.exports = NvSpPrXform;

--- a/lib/xlsx/xform/drawing/one-cell-anchor-xform.js
+++ b/lib/xlsx/xform/drawing/one-cell-anchor-xform.js
@@ -3,8 +3,8 @@ const StaticXform = require('../static-xform');
 
 const CellPositionXform = require('./cell-position-xform');
 const ExtXform = require('./ext-xform');
-const PicXform = require('./pic-xform');
-const SpXform = require('./sp-xform');
+const PicXform = require('./picture/pic-xform');
+const SpXform = require('./shape/sp-xform');
 
 class OneCellAnchorXform extends BaseCellAnchorXform {
   constructor() {

--- a/lib/xlsx/xform/drawing/one-cell-anchor-xform.js
+++ b/lib/xlsx/xform/drawing/one-cell-anchor-xform.js
@@ -4,6 +4,7 @@ const StaticXform = require('../static-xform');
 const CellPositionXform = require('./cell-position-xform');
 const ExtXform = require('./ext-xform');
 const PicXform = require('./pic-xform');
+const SpXform = require('./sp-xform');
 
 class OneCellAnchorXform extends BaseCellAnchorXform {
   constructor() {
@@ -13,6 +14,7 @@ class OneCellAnchorXform extends BaseCellAnchorXform {
       'xdr:from': new CellPositionXform({tag: 'xdr:from'}),
       'xdr:ext': new ExtXform({tag: 'xdr:ext'}),
       'xdr:pic': new PicXform(),
+      'xdr:sp': new SpXform(),
       'xdr:clientData': new StaticXform({tag: 'xdr:clientData'}),
     };
   }
@@ -22,7 +24,12 @@ class OneCellAnchorXform extends BaseCellAnchorXform {
   }
 
   prepare(model, options) {
-    this.map['xdr:pic'].prepare(model.picture, options);
+    if (model.picture) {
+      this.map['xdr:pic'].prepare(model.picture, options);
+    }
+    if (model.shape) {
+      this.map['xdr:sp'].prepare(model.shape, options);
+    }
   }
 
   render(xmlStream, model) {
@@ -30,7 +37,12 @@ class OneCellAnchorXform extends BaseCellAnchorXform {
 
     this.map['xdr:from'].render(xmlStream, model.range.tl);
     this.map['xdr:ext'].render(xmlStream, model.range.ext);
-    this.map['xdr:pic'].render(xmlStream, model.picture);
+    if (model.picture) {
+      this.map['xdr:pic'].render(xmlStream, model.picture);
+    }
+    if (model.shape) {
+      this.map['xdr:sp'].render(xmlStream, model.shape);
+    }
     this.map['xdr:clientData'].render(xmlStream, {});
 
     xmlStream.closeNode();
@@ -48,6 +60,7 @@ class OneCellAnchorXform extends BaseCellAnchorXform {
         this.model.range.tl = this.map['xdr:from'].model;
         this.model.range.ext = this.map['xdr:ext'].model;
         this.model.picture = this.map['xdr:pic'].model;
+        this.model.shape = this.map['xdr:sp'].model;
         return false;
       default:
         // could be some unrecognised tags

--- a/lib/xlsx/xform/drawing/picture/c-nv-pic-pr-xform.js
+++ b/lib/xlsx/xform/drawing/picture/c-nv-pic-pr-xform.js
@@ -1,4 +1,4 @@
-const BaseXform = require('../base-xform');
+const BaseXform = require('../../base-xform');
 
 class CNvPicPrXform extends BaseXform {
   get tag() {

--- a/lib/xlsx/xform/drawing/picture/nv-pic-pr-xform.js
+++ b/lib/xlsx/xform/drawing/picture/nv-pic-pr-xform.js
@@ -1,26 +1,25 @@
-const BaseXform = require('../base-xform');
-const XfrmXform = require('./xfrm-xform');
-const PrstGeomXform = require('./prst-geom-xform');
+const BaseXform = require('../../base-xform');
+const CNvPrXform = require('../c-nv-pr-xform');
+const CNvPicPrXform = require('./c-nv-pic-pr-xform');
 
-// DocumentFormat.OpenXml.Drawing.Spreadsheet.ShapeProperties
-class SpPrXform extends BaseXform {
+class NvPicPrXform extends BaseXform {
   constructor() {
     super();
 
     this.map = {
-      'a:xfrm': new XfrmXform(),
-      'a:prstGeom': new PrstGeomXform(),
+      'xdr:cNvPr': new CNvPrXform(true),
+      'xdr:cNvPicPr': new CNvPicPrXform(),
     };
   }
 
   get tag() {
-    return 'xdr:spPr';
+    return 'xdr:nvPicPr';
   }
 
-  render(xmlStream, shape) {
+  render(xmlStream, model) {
     xmlStream.openNode(this.tag);
-    this.map['a:xfrm'].render(xmlStream, shape);
-    this.map['a:prstGeom'].render(xmlStream, shape);
+    this.map['xdr:cNvPr'].render(xmlStream, model);
+    this.map['xdr:cNvPicPr'].render(xmlStream, model);
     xmlStream.closeNode();
   }
 
@@ -32,7 +31,7 @@ class SpPrXform extends BaseXform {
 
     switch (node.name) {
       case this.tag:
-        this.model = {};
+        this.reset();
         break;
       default:
         this.parser = this.map[node.name];
@@ -55,10 +54,7 @@ class SpPrXform extends BaseXform {
     }
     switch (name) {
       case this.tag:
-        this.mergeModel({
-          ...this.map['a:xfrm'].model,
-          ...this.map['a:prstGeom'].model,
-        });
+        this.model = this.map['xdr:cNvPr'].model;
         return false;
       default:
         return true;
@@ -66,4 +62,4 @@ class SpPrXform extends BaseXform {
   }
 }
 
-module.exports = SpPrXform;
+module.exports = NvPicPrXform;

--- a/lib/xlsx/xform/drawing/picture/pic-xform.js
+++ b/lib/xlsx/xform/drawing/picture/pic-xform.js
@@ -1,10 +1,10 @@
-const BaseXform = require('../base-xform');
-const StaticXform = require('../static-xform');
+const BaseXform = require('../../base-xform');
+const StaticXform = require('../../static-xform');
 
-const BlipFillXform = require('./blip-fill-xform');
+const BlipFillXform = require('../blip-fill-xform');
 const NvPicPrXform = require('./nv-pic-pr-xform');
 
-const spPrJSON = require('./sp-pr');
+const spPrJSON = require('../sp-pr');
 
 class PicXform extends BaseXform {
   constructor() {

--- a/lib/xlsx/xform/drawing/prst-geom-xform.js
+++ b/lib/xlsx/xform/drawing/prst-geom-xform.js
@@ -1,25 +1,20 @@
 const BaseXform = require('../base-xform');
-const CNvPrXform = require('./c-nv-pr-xform');
-const CNvPicPrXform = require('./c-nv-pic-pr-xform');
 
-class NvPicPrXform extends BaseXform {
+// DocumentFormat.OpenXml.Drawing.PresetGeometry
+class PrstGeomXform extends BaseXform {
   constructor() {
     super();
 
-    this.map = {
-      'xdr:cNvPr': new CNvPrXform(true),
-      'xdr:cNvPicPr': new CNvPicPrXform(),
-    };
+    this.map = {};
   }
 
   get tag() {
-    return 'xdr:nvPicPr';
+    return 'a:prstGeom';
   }
 
   render(xmlStream, model) {
-    xmlStream.openNode(this.tag);
-    this.map['xdr:cNvPr'].render(xmlStream, model);
-    this.map['xdr:cNvPicPr'].render(xmlStream, model);
+    xmlStream.openNode(this.tag, {prst: model.type});
+    xmlStream.leafNode('a:avLst', {});
     xmlStream.closeNode();
   }
 
@@ -31,7 +26,7 @@ class NvPicPrXform extends BaseXform {
 
     switch (node.name) {
       case this.tag:
-        this.reset();
+        this.model = {type: node.attributes.prst};
         break;
       default:
         this.parser = this.map[node.name];
@@ -54,7 +49,7 @@ class NvPicPrXform extends BaseXform {
     }
     switch (name) {
       case this.tag:
-        this.model = this.map['xdr:cNvPr'].model;
+        // TOOD avLst
         return false;
       default:
         return true;
@@ -62,4 +57,4 @@ class NvPicPrXform extends BaseXform {
   }
 }
 
-module.exports = NvPicPrXform;
+module.exports = PrstGeomXform;

--- a/lib/xlsx/xform/drawing/shape/ln-xform.js
+++ b/lib/xlsx/xform/drawing/shape/ln-xform.js
@@ -1,0 +1,73 @@
+const BaseXform = require('../../base-xform');
+const SolidFillXform = require('./solid-fill-xform');
+
+// DocumentFormat.OpenXml.Drawing.Outline
+class LnXform extends BaseXform {
+  constructor() {
+    super();
+
+    this.map = {
+      'a:solidFill': new SolidFillXform(),
+    };
+  }
+
+  get tag() {
+    return 'a:ln';
+  }
+
+  render(xmlStream, outline) {
+    xmlStream.openNode(this.tag);
+    if (outline.weight) {
+      xmlStream.addAttribute('w', outline.weight * 12700);
+    }
+    if (outline.color) {
+      this.map['a:solidFill'].render(xmlStream, outline.color);
+    }
+    xmlStream.closeNode();
+  }
+
+  parseOpen(node) {
+    if (this.parser) {
+      this.parser.parseOpen(node);
+      return true;
+    }
+
+    switch (node.name) {
+      case this.tag:
+        this.model = {};
+        if (node.attributes.w) {
+          this.model.weight = parseInt(node.attributes.w, 10) / 12700;
+        }
+        break;
+      default:
+        this.parser = this.map[node.name];
+        if (this.parser) {
+          this.parser.parseOpen(node);
+        }
+        break;
+    }
+    return true;
+  }
+
+  parseText() {}
+
+  parseClose(name) {
+    if (this.parser) {
+      if (!this.parser.parseClose(name)) {
+        this.parser = undefined;
+      }
+      return true;
+    }
+    switch (name) {
+      case this.tag:
+        if (this.map['a:solidFill'].model) {
+          this.model.color = this.map['a:solidFill'].model;
+        }
+        return false;
+      default:
+        return true;
+    }
+  }
+}
+
+module.exports = LnXform;

--- a/lib/xlsx/xform/drawing/shape/ln-xform.js
+++ b/lib/xlsx/xform/drawing/shape/ln-xform.js
@@ -23,6 +23,25 @@ class LnXform extends BaseXform {
     if (outline.color) {
       this.map['a:solidFill'].render(xmlStream, outline.color);
     }
+    if (outline.dash) {
+      xmlStream.leafNode('a:prstDash', {val: outline.dash});
+    }
+    if (outline.arrow) {
+      if (outline.arrow.head) {
+        xmlStream.leafNode('a:headEnd', {
+          type: outline.arrow.head.type,
+          w: outline.arrow.head.width,
+          len: outline.arrow.head.length,
+        });
+      }
+      if (outline.arrow.tail) {
+        xmlStream.leafNode('a:tailEnd', {
+          type: outline.arrow.tail.type,
+          w: outline.arrow.tail.width,
+          len: outline.arrow.tail.length,
+        });
+      }
+    }
     xmlStream.closeNode();
   }
 
@@ -38,6 +57,25 @@ class LnXform extends BaseXform {
         if (node.attributes.w) {
           this.model.weight = parseInt(node.attributes.w, 10) / 12700;
         }
+        break;
+      case 'a:prstDash':
+        this.model.dash = node.attributes.val;
+        break;
+      case 'a:headEnd':
+        this.model.arrow = this.model.arrow || {};
+        this.model.arrow.head = {
+          type: node.attributes.type,
+          width: node.attributes.w,
+          length: node.attributes.len,
+        };
+        break;
+      case 'a:tailEnd':
+        this.model.arrow = this.model.arrow || {};
+        this.model.arrow.tail = {
+          type: node.attributes.type,
+          width: node.attributes.w,
+          length: node.attributes.len,
+        };
         break;
       default:
         this.parser = this.map[node.name];

--- a/lib/xlsx/xform/drawing/shape/nv-sp-pr-xform.js
+++ b/lib/xlsx/xform/drawing/shape/nv-sp-pr-xform.js
@@ -1,20 +1,24 @@
-const BaseXform = require('../base-xform');
+const BaseXform = require('../../base-xform');
+const CNvPrXform = require('../c-nv-pr-xform');
 
-// DocumentFormat.OpenXml.Drawing.PresetGeometry
-class PrstGeomXform extends BaseXform {
+// DocumentFormat.OpenXml.Drawing.Spreadsheet.NonVisualShapeProperties
+class NvSpPrXform extends BaseXform {
   constructor() {
     super();
 
-    this.map = {};
+    this.map = {
+      'xdr:cNvPr': new CNvPrXform(false),
+    };
   }
 
   get tag() {
-    return 'a:prstGeom';
+    return 'xdr:nvSpPr';
   }
 
-  render(xmlStream, model) {
-    xmlStream.openNode(this.tag, {prst: model.type});
-    xmlStream.leafNode('a:avLst', {});
+  render(xmlStream, shape) {
+    xmlStream.openNode(this.tag);
+    this.map['xdr:cNvPr'].render(xmlStream, shape);
+    xmlStream.leafNode('xdr:cNvSpPr');
     xmlStream.closeNode();
   }
 
@@ -26,7 +30,6 @@ class PrstGeomXform extends BaseXform {
 
     switch (node.name) {
       case this.tag:
-        this.model = {type: node.attributes.prst};
         break;
       default:
         this.parser = this.map[node.name];
@@ -49,7 +52,7 @@ class PrstGeomXform extends BaseXform {
     }
     switch (name) {
       case this.tag:
-        // TOOD avLst
+        this.model = this.map['xdr:cNvPr'].model;
         return false;
       default:
         return true;
@@ -57,4 +60,4 @@ class PrstGeomXform extends BaseXform {
   }
 }
 
-module.exports = PrstGeomXform;
+module.exports = NvSpPrXform;

--- a/lib/xlsx/xform/drawing/shape/p-xform.js
+++ b/lib/xlsx/xform/drawing/shape/p-xform.js
@@ -17,7 +17,11 @@ class ParagraphXform extends BaseXform {
 
   render(xmlStream, paragraph) {
     xmlStream.openNode('a:p');
-    xmlStream.leafNode('a:pPr', {algn: 'l'});
+    xmlStream.openNode('a:pPr');
+    if (paragraph.alignment) {
+      xmlStream.addAttribute('algn', paragraph.alignment);
+    }
+    xmlStream.closeNode();
     paragraph.runs.forEach(r => {
       this.map['a:r'].render(xmlStream, r);
     });
@@ -33,6 +37,11 @@ class ParagraphXform extends BaseXform {
     switch (node.name) {
       case this.tag:
         this.model = {runs: []};
+        break;
+      case 'a:pPr':
+        if (node.attributes.algn) {
+          this.model.alignment = node.attributes.algn;
+        }
         break;
       default:
         this.parser = this.map[node.name];

--- a/lib/xlsx/xform/drawing/shape/p-xform.js
+++ b/lib/xlsx/xform/drawing/shape/p-xform.js
@@ -1,0 +1,72 @@
+const BaseXform = require('../../base-xform');
+const RunXform = require('./r-xform');
+
+// DocumentFormat.OpenXml.Drawing.Paragraph
+class ParagraphXform extends BaseXform {
+  constructor() {
+    super();
+
+    this.map = {
+      'a:r': new RunXform(),
+    };
+  }
+
+  get tag() {
+    return 'a:p';
+  }
+
+  render(xmlStream, paragraph) {
+    xmlStream.openNode('a:p');
+    xmlStream.leafNode('a:pPr', {algn: 'l'});
+    paragraph.runs.forEach(r => {
+      this.map['a:r'].render(xmlStream, r);
+    });
+    xmlStream.closeNode();
+  }
+
+  parseOpen(node) {
+    if (this.parser) {
+      this.parser.parseOpen(node);
+      return true;
+    }
+
+    switch (node.name) {
+      case this.tag:
+        this.model = {runs: []};
+        break;
+      default:
+        this.parser = this.map[node.name];
+        if (this.parser) {
+          this.parser.parseOpen(node);
+        }
+        break;
+    }
+    return true;
+  }
+
+  parseText(text) {
+    if (this.parser) {
+      this.parser.parseText(text);
+    }
+  }
+
+  parseClose(name) {
+    if (this.parser) {
+      if (!this.parser.parseClose(name)) {
+        if (name === 'a:r') {
+          this.model.runs.push(this.parser.model);
+        }
+        this.parser = undefined;
+      }
+      return true;
+    }
+    switch (name) {
+      case this.tag:
+        return false;
+      default:
+        return true;
+    }
+  }
+}
+
+module.exports = ParagraphXform;

--- a/lib/xlsx/xform/drawing/shape/prst-geom-xform.js
+++ b/lib/xlsx/xform/drawing/shape/prst-geom-xform.js
@@ -1,24 +1,20 @@
-const BaseXform = require('../base-xform');
-const CNvPrXform = require('./c-nv-pr-xform');
+const BaseXform = require('../../base-xform');
 
-// DocumentFormat.OpenXml.Drawing.Spreadsheet.NonVisualShapeProperties
-class NvSpPrXform extends BaseXform {
+// DocumentFormat.OpenXml.Drawing.PresetGeometry
+class PrstGeomXform extends BaseXform {
   constructor() {
     super();
 
-    this.map = {
-      'xdr:cNvPr': new CNvPrXform(false),
-    };
+    this.map = {};
   }
 
   get tag() {
-    return 'xdr:nvSpPr';
+    return 'a:prstGeom';
   }
 
-  render(xmlStream, shape) {
-    xmlStream.openNode(this.tag);
-    this.map['xdr:cNvPr'].render(xmlStream, shape);
-    xmlStream.leafNode('xdr:cNvSpPr');
+  render(xmlStream, model) {
+    xmlStream.openNode(this.tag, {prst: model.type});
+    xmlStream.leafNode('a:avLst', {});
     xmlStream.closeNode();
   }
 
@@ -30,6 +26,7 @@ class NvSpPrXform extends BaseXform {
 
     switch (node.name) {
       case this.tag:
+        this.model = {type: node.attributes.prst};
         break;
       default:
         this.parser = this.map[node.name];
@@ -52,7 +49,7 @@ class NvSpPrXform extends BaseXform {
     }
     switch (name) {
       case this.tag:
-        this.model = this.map['xdr:cNvPr'].model;
+        // TOOD avLst
         return false;
       default:
         return true;
@@ -60,4 +57,4 @@ class NvSpPrXform extends BaseXform {
   }
 }
 
-module.exports = NvSpPrXform;
+module.exports = PrstGeomXform;

--- a/lib/xlsx/xform/drawing/shape/r-xform.js
+++ b/lib/xlsx/xform/drawing/shape/r-xform.js
@@ -1,7 +1,16 @@
 const BaseXform = require('../../base-xform');
+const SolidFillXform = require('./solid-fill-xform');
 
 // DocumentFormat.OpenXml.Drawing.Run
 class RunXform extends BaseXform {
+  constructor() {
+    super();
+
+    this.map = {
+      'a:solidFill': new SolidFillXform(),
+    };
+  }
+
   get tag() {
     return 'a:r';
   }
@@ -17,6 +26,9 @@ class RunXform extends BaseXform {
         u: run.font.underline || undefined,
       });
     }
+    if (run.font && run.font.color) {
+      this.map['a:solidFill'].render(xmlStream, run.font.color);
+    }
     xmlStream.closeNode();
     xmlStream.leafNode('a:t', undefined, run.text);
     xmlStream.closeNode();
@@ -30,10 +42,9 @@ class RunXform extends BaseXform {
 
     switch (node.name) {
       case this.tag:
-        this.model = {text: ''};
+        this.model = {text: '', font: {}};
         break;
       case 'a:rPr':
-        this.model.font = {};
         if (node.attributes.sz) {
           this.model.font.size = parseInt(node.attributes.sz, 10) / 100;
         }
@@ -48,6 +59,10 @@ class RunXform extends BaseXform {
         }
         break;
       default:
+        this.parser = this.map[node.name];
+        if (this.parser) {
+          this.parser.parseOpen(node);
+        }
         break;
     }
     return true;
@@ -66,6 +81,9 @@ class RunXform extends BaseXform {
     }
     switch (name) {
       case this.tag:
+        if (this.map['a:solidFill'].model) {
+          this.model.font.color = this.map['a:solidFill'].model;
+        }
         return false;
       default:
         return true;

--- a/lib/xlsx/xform/drawing/shape/r-xform.js
+++ b/lib/xlsx/xform/drawing/shape/r-xform.js
@@ -8,7 +8,16 @@ class RunXform extends BaseXform {
 
   render(xmlStream, run) {
     xmlStream.openNode(this.tag);
-    xmlStream.leafNode('a:rPr');
+    xmlStream.openNode('a:rPr');
+    if (run.font) {
+      xmlStream.addAttributes({
+        sz: run.font.size ? run.font.size * 100 : undefined,
+        b: run.font.bold ? 1 : undefined,
+        i: run.font.italic ? 1 : undefined,
+        u: run.font.underline || undefined,
+      });
+    }
+    xmlStream.closeNode();
     xmlStream.leafNode('a:t', undefined, run.text);
     xmlStream.closeNode();
   }
@@ -22,6 +31,21 @@ class RunXform extends BaseXform {
     switch (node.name) {
       case this.tag:
         this.model = {text: ''};
+        break;
+      case 'a:rPr':
+        this.model.font = {};
+        if (node.attributes.sz) {
+          this.model.font.size = parseInt(node.attributes.sz, 10) / 100;
+        }
+        if (node.attributes.b) {
+          this.model.font.bold = node.attributes.b === '1';
+        }
+        if (node.attributes.i) {
+          this.model.font.italic = node.attributes.i === '1';
+        }
+        if (node.attributes.u) {
+          this.model.font.underline = node.attributes.u;
+        }
         break;
       default:
         break;

--- a/lib/xlsx/xform/drawing/shape/r-xform.js
+++ b/lib/xlsx/xform/drawing/shape/r-xform.js
@@ -1,0 +1,52 @@
+const BaseXform = require('../../base-xform');
+
+// DocumentFormat.OpenXml.Drawing.Run
+class RunXform extends BaseXform {
+  get tag() {
+    return 'a:r';
+  }
+
+  render(xmlStream, run) {
+    xmlStream.openNode(this.tag);
+    xmlStream.leafNode('a:rPr');
+    xmlStream.leafNode('a:t', undefined, run.text);
+    xmlStream.closeNode();
+  }
+
+  parseOpen(node) {
+    if (this.parser) {
+      this.parser.parseOpen(node);
+      return true;
+    }
+
+    switch (node.name) {
+      case this.tag:
+        this.model = {text: ''};
+        break;
+      default:
+        break;
+    }
+    return true;
+  }
+
+  parseText(text) {
+    this.model.text = text.replace(/_x([0-9A-F]{4})_/g, ($0, $1) => String.fromCharCode(parseInt($1, 16)));
+  }
+
+  parseClose(name) {
+    if (this.parser) {
+      if (!this.parser.parseClose(name)) {
+        this.parser = undefined;
+      }
+      return true;
+    }
+    switch (name) {
+      case this.tag:
+        return false;
+      default:
+        return true;
+    }
+  }
+}
+
+module.exports = RunXform;

--- a/lib/xlsx/xform/drawing/shape/r-xform.js
+++ b/lib/xlsx/xform/drawing/shape/r-xform.js
@@ -43,6 +43,7 @@ class RunXform extends BaseXform {
     switch (node.name) {
       case this.tag:
         this.model = {text: '', font: {}};
+        this.parsingText = false;
         break;
       case 'a:rPr':
         if (node.attributes.sz) {
@@ -58,6 +59,9 @@ class RunXform extends BaseXform {
           this.model.font.underline = node.attributes.u;
         }
         break;
+      case 'a:t':
+        this.parsingText = true;
+        break;
       default:
         this.parser = this.map[node.name];
         if (this.parser) {
@@ -69,7 +73,9 @@ class RunXform extends BaseXform {
   }
 
   parseText(text) {
-    this.model.text = text.replace(/_x([0-9A-F]{4})_/g, ($0, $1) => String.fromCharCode(parseInt($1, 16)));
+    if (this.parsingText) {
+      this.model.text = text.replace(/_x([0-9A-F]{4})_/g, ($0, $1) => String.fromCharCode(parseInt($1, 16)));
+    }
   }
 
   parseClose(name) {
@@ -85,6 +91,9 @@ class RunXform extends BaseXform {
           this.model.font.color = this.map['a:solidFill'].model;
         }
         return false;
+      case 'a:t':
+        this.parsingText = false;
+        return true;
       default:
         return true;
     }

--- a/lib/xlsx/xform/drawing/shape/solid-fill-xform.js
+++ b/lib/xlsx/xform/drawing/shape/solid-fill-xform.js
@@ -1,0 +1,66 @@
+const BaseXform = require('../../base-xform');
+
+// DocumentFormat.OpenXml.Drawing.SolidFill
+class SolidFillXform extends BaseXform {
+  constructor() {
+    super();
+
+    this.map = {};
+  }
+
+  get tag() {
+    return 'a:solidFill';
+  }
+
+  render(xmlStream, color) {
+    xmlStream.openNode(this.tag);
+    if (color.theme) {
+      xmlStream.leafNode('a:schemeClr', {val: color.theme});
+    }
+    xmlStream.closeNode();
+  }
+
+  parseOpen(node) {
+    if (this.parser) {
+      this.parser.parseOpen(node);
+      return true;
+    }
+
+    switch (node.name) {
+      case this.tag:
+        this.reset();
+        this.model = {};
+        break;
+      case 'a:schemeClr':
+        this.model.theme = node.attributes.val;
+        break;
+      default:
+        this.parser = this.map[node.name];
+        if (this.parser) {
+          this.parser.parseOpen(node);
+        }
+        break;
+    }
+    return true;
+  }
+
+  parseText() {}
+
+  parseClose(name) {
+    if (this.parser) {
+      if (!this.parser.parseClose(name)) {
+        this.parser = undefined;
+      }
+      return true;
+    }
+    switch (name) {
+      case this.tag:
+        return false;
+
+      default:
+        return true;
+    }
+  }
+}
+
+module.exports = SolidFillXform;

--- a/lib/xlsx/xform/drawing/shape/solid-fill-xform.js
+++ b/lib/xlsx/xform/drawing/shape/solid-fill-xform.js
@@ -16,6 +16,8 @@ class SolidFillXform extends BaseXform {
     xmlStream.openNode(this.tag);
     if (color.theme) {
       xmlStream.leafNode('a:schemeClr', {val: color.theme});
+    } else if (color.rgb) {
+      xmlStream.leafNode('a:srgbClr', {val: color.rgb});
     }
     xmlStream.closeNode();
   }
@@ -33,6 +35,9 @@ class SolidFillXform extends BaseXform {
         break;
       case 'a:schemeClr':
         this.model.theme = node.attributes.val;
+        break;
+      case 'a:srgbClr':
+        this.model.rgb = node.attributes.val;
         break;
       default:
         this.parser = this.map[node.name];

--- a/lib/xlsx/xform/drawing/shape/sp-pr-xform.js
+++ b/lib/xlsx/xform/drawing/shape/sp-pr-xform.js
@@ -23,7 +23,7 @@ class SpPrXform extends BaseXform {
 
   render(xmlStream, shape) {
     xmlStream.openNode(this.tag);
-    this.map['a:xfrm'].render(xmlStream);
+    this.map['a:xfrm'].render(xmlStream, shape);
     this.map['a:prstGeom'].render(xmlStream, shape);
     if (shape.fill && shape.fill.type === 'solid') {
       this.map['a:solidFill'].render(xmlStream, shape.fill.color);
@@ -82,6 +82,9 @@ class SpPrXform extends BaseXform {
         }
         if (this.map['a:ln'].model) {
           this.model.outline = this.map['a:ln'].model;
+        }
+        if (this.map['a:xfrm'].model) {
+          this.mergeModel(this.map['a:xfrm'].model);
         }
         return false;
       default:

--- a/lib/xlsx/xform/drawing/shape/sp-pr-xform.js
+++ b/lib/xlsx/xform/drawing/shape/sp-pr-xform.js
@@ -23,7 +23,7 @@ class SpPrXform extends BaseXform {
 
   render(xmlStream, shape) {
     xmlStream.openNode(this.tag);
-    this.map['a:xfrm'].render(xmlStream, shape);
+    this.map['a:xfrm'].render(xmlStream);
     this.map['a:prstGeom'].render(xmlStream, shape);
     if (shape.fill && shape.fill.type === 'solid') {
       this.map['a:solidFill'].render(xmlStream, shape.fill.color);
@@ -67,22 +67,17 @@ class SpPrXform extends BaseXform {
     }
     switch (name) {
       case this.tag:
-        this.mergeModel({
-          ...this.map['a:xfrm'].model,
-          ...this.map['a:prstGeom'].model,
-        });
+        if (this.map['a:prstGeom'].model) {
+          this.model.type = this.map['a:prstGeom'].model.type;
+        }
         if (this.map['a:solidFill'].model) {
-          this.mergeModel({
-            fill: {
-              type: 'solid',
-              color: this.map['a:solidFill'].model,
-            },
-          });
+          this.model.fill = {
+            type: 'solid',
+            color: this.map['a:solidFill'].model,
+          };
         }
         if (this.map['a:ln'].model) {
-          this.mergeModel({
-            outline: this.map['a:ln'].model,
-          });
+          this.model.outline = this.map['a:ln'].model;
         }
         return false;
       default:

--- a/lib/xlsx/xform/drawing/shape/sp-pr-xform.js
+++ b/lib/xlsx/xform/drawing/shape/sp-pr-xform.js
@@ -45,6 +45,10 @@ class SpPrXform extends BaseXform {
     switch (node.name) {
       case this.tag:
         this.model = {};
+        this.noFill = false;
+        break;
+      case 'a:noFill':
+        this.noFill = true;
         break;
       default:
         this.parser = this.map[node.name];

--- a/lib/xlsx/xform/drawing/shape/sp-pr-xform.js
+++ b/lib/xlsx/xform/drawing/shape/sp-pr-xform.js
@@ -1,6 +1,7 @@
 const BaseXform = require('../../base-xform');
 const XfrmXform = require('../xfrm-xform');
 const PrstGeomXform = require('./prst-geom-xform');
+const SolidFillXform = require('./solid-fill-xform');
 
 // DocumentFormat.OpenXml.Drawing.Spreadsheet.ShapeProperties
 class SpPrXform extends BaseXform {
@@ -10,6 +11,7 @@ class SpPrXform extends BaseXform {
     this.map = {
       'a:xfrm': new XfrmXform(),
       'a:prstGeom': new PrstGeomXform(),
+      'a:solidFill': new SolidFillXform(),
     };
   }
 
@@ -21,6 +23,11 @@ class SpPrXform extends BaseXform {
     xmlStream.openNode(this.tag);
     this.map['a:xfrm'].render(xmlStream, shape);
     this.map['a:prstGeom'].render(xmlStream, shape);
+    if (shape.fill && shape.fill.type === 'solid') {
+      this.map['a:solidFill'].render(xmlStream, shape.fill.color);
+    } else {
+      xmlStream.leafNode('a:noFill');
+    }
     xmlStream.closeNode();
   }
 
@@ -59,6 +66,14 @@ class SpPrXform extends BaseXform {
           ...this.map['a:xfrm'].model,
           ...this.map['a:prstGeom'].model,
         });
+        if (this.map['a:solidFill'].model) {
+          this.mergeModel({
+            fill: {
+              type: 'solid',
+              color: this.map['a:solidFill'].model,
+            },
+          });
+        }
         return false;
       default:
         return true;

--- a/lib/xlsx/xform/drawing/shape/sp-pr-xform.js
+++ b/lib/xlsx/xform/drawing/shape/sp-pr-xform.js
@@ -1,25 +1,26 @@
-const BaseXform = require('../base-xform');
-const CNvPrXform = require('./c-nv-pr-xform');
-const CNvPicPrXform = require('./c-nv-pic-pr-xform');
+const BaseXform = require('../../base-xform');
+const XfrmXform = require('../xfrm-xform');
+const PrstGeomXform = require('./prst-geom-xform');
 
-class NvPicPrXform extends BaseXform {
+// DocumentFormat.OpenXml.Drawing.Spreadsheet.ShapeProperties
+class SpPrXform extends BaseXform {
   constructor() {
     super();
 
     this.map = {
-      'xdr:cNvPr': new CNvPrXform(true),
-      'xdr:cNvPicPr': new CNvPicPrXform(),
+      'a:xfrm': new XfrmXform(),
+      'a:prstGeom': new PrstGeomXform(),
     };
   }
 
   get tag() {
-    return 'xdr:nvPicPr';
+    return 'xdr:spPr';
   }
 
-  render(xmlStream, model) {
+  render(xmlStream, shape) {
     xmlStream.openNode(this.tag);
-    this.map['xdr:cNvPr'].render(xmlStream, model);
-    this.map['xdr:cNvPicPr'].render(xmlStream, model);
+    this.map['a:xfrm'].render(xmlStream, shape);
+    this.map['a:prstGeom'].render(xmlStream, shape);
     xmlStream.closeNode();
   }
 
@@ -31,7 +32,7 @@ class NvPicPrXform extends BaseXform {
 
     switch (node.name) {
       case this.tag:
-        this.reset();
+        this.model = {};
         break;
       default:
         this.parser = this.map[node.name];
@@ -54,7 +55,10 @@ class NvPicPrXform extends BaseXform {
     }
     switch (name) {
       case this.tag:
-        this.model = this.map['xdr:cNvPr'].model;
+        this.mergeModel({
+          ...this.map['a:xfrm'].model,
+          ...this.map['a:prstGeom'].model,
+        });
         return false;
       default:
         return true;
@@ -62,4 +66,4 @@ class NvPicPrXform extends BaseXform {
   }
 }
 
-module.exports = NvPicPrXform;
+module.exports = SpPrXform;

--- a/lib/xlsx/xform/drawing/shape/sp-pr-xform.js
+++ b/lib/xlsx/xform/drawing/shape/sp-pr-xform.js
@@ -2,6 +2,7 @@ const BaseXform = require('../../base-xform');
 const XfrmXform = require('../xfrm-xform');
 const PrstGeomXform = require('./prst-geom-xform');
 const SolidFillXform = require('./solid-fill-xform');
+const LnXform = require('./ln-xform');
 
 // DocumentFormat.OpenXml.Drawing.Spreadsheet.ShapeProperties
 class SpPrXform extends BaseXform {
@@ -12,6 +13,7 @@ class SpPrXform extends BaseXform {
       'a:xfrm': new XfrmXform(),
       'a:prstGeom': new PrstGeomXform(),
       'a:solidFill': new SolidFillXform(),
+      'a:ln': new LnXform(),
     };
   }
 
@@ -27,6 +29,9 @@ class SpPrXform extends BaseXform {
       this.map['a:solidFill'].render(xmlStream, shape.fill.color);
     } else {
       xmlStream.leafNode('a:noFill');
+    }
+    if (shape.outline) {
+      this.map['a:ln'].render(xmlStream, shape.outline);
     }
     xmlStream.closeNode();
   }
@@ -72,6 +77,11 @@ class SpPrXform extends BaseXform {
               type: 'solid',
               color: this.map['a:solidFill'].model,
             },
+          });
+        }
+        if (this.map['a:ln'].model) {
+          this.mergeModel({
+            outline: this.map['a:ln'].model,
           });
         }
         return false;

--- a/lib/xlsx/xform/drawing/shape/sp-xform.js
+++ b/lib/xlsx/xform/drawing/shape/sp-xform.js
@@ -30,10 +30,10 @@ class SpXform extends BaseXform {
     xmlStream.openNode(this.tag, {macro: '', textlink: ''});
 
     this.map['xdr:nvSpPr'].render(xmlStream, shape);
-    this.map['xdr:spPr'].render(xmlStream, shape);
-    this.map['xdr:style'].render(xmlStream, shape);
-    if (shape.textBody) {
-      this.map['xdr:txBody'].render(xmlStream, shape.textBody);
+    this.map['xdr:spPr'].render(xmlStream, shape.props);
+    this.map['xdr:style'].render(xmlStream, shape.props);
+    if (shape.props.textBody) {
+      this.map['xdr:txBody'].render(xmlStream, shape.props.textBody);
     }
     xmlStream.closeNode();
   }
@@ -41,6 +41,7 @@ class SpXform extends BaseXform {
   parseOpen(node) {
     if (this.parser) {
       this.parser.parseOpen(node);
+      this.model = {props: {}};
       return true;
     }
     switch (node.name) {
@@ -71,16 +72,19 @@ class SpXform extends BaseXform {
     }
     switch (name) {
       case this.tag:
-        this.mergeModel({
+        this.model.props = {
           ...(this.map['xdr:style'].model.fill ? {fill: this.map['xdr:style'].model.fill} : {}),
           ...(this.map['xdr:style'].model.outline ? {outline: this.map['xdr:style'].model.outline} : {}),
           ...this.map['xdr:spPr'].model,
-        });
+        };
         if (this.map['xdr:txBody'].model) {
-          this.model.textBody = this.map['xdr:txBody'].model;
+          this.model.props.textBody = this.map['xdr:txBody'].model;
         }
         if (this.map['xdr:spPr'].noFill) {
-          delete this.model.fill;
+          delete this.model.props.fill;
+        }
+        if (this.map['xdr:nvSpPr'].model) {
+          this.model.hyperlinks = this.map['xdr:nvSpPr'].model.hyperlinks;
         }
         return false;
       default:

--- a/lib/xlsx/xform/drawing/shape/sp-xform.js
+++ b/lib/xlsx/xform/drawing/shape/sp-xform.js
@@ -3,6 +3,7 @@ const BaseXform = require('../../base-xform');
 const NvSpPrXform = require('./nv-sp-pr-xform');
 const SpPrXform = require('./sp-pr-xform');
 const StyleXform = require('./style-xform');
+const TxBodyXform = require('./tx-body-xform');
 
 // DocumentFormat.OpenXml.Drawing.Spreadsheet.Shape
 class SpXform extends BaseXform {
@@ -13,6 +14,7 @@ class SpXform extends BaseXform {
       'xdr:nvSpPr': new NvSpPrXform(),
       'xdr:spPr': new SpPrXform(),
       'xdr:style': new StyleXform(),
+      'xdr:txBody': new TxBodyXform(),
     };
   }
 
@@ -24,13 +26,15 @@ class SpXform extends BaseXform {
     model.index = options.index + 1;
   }
 
-  render(xmlStream, model) {
+  render(xmlStream, shape) {
     xmlStream.openNode(this.tag, {macro: '', textlink: ''});
 
-    this.map['xdr:nvSpPr'].render(xmlStream, model);
-    this.map['xdr:spPr'].render(xmlStream, model);
-    this.map['xdr:style'].render(xmlStream, model);
-
+    this.map['xdr:nvSpPr'].render(xmlStream, shape);
+    this.map['xdr:spPr'].render(xmlStream, shape);
+    this.map['xdr:style'].render(xmlStream, shape);
+    if (shape.textBody) {
+      this.map['xdr:txBody'].render(xmlStream, shape.textBody);
+    }
     xmlStream.closeNode();
   }
 
@@ -72,6 +76,9 @@ class SpXform extends BaseXform {
           ...(this.map['xdr:style'].model.outline ? {outline: this.map['xdr:style'].model.outline} : {}),
           ...this.map['xdr:spPr'].model,
         });
+        if (this.map['xdr:txBody'].model) {
+          this.model.textBody = this.map['xdr:txBody'].model;
+        }
         return false;
       default:
         return true;

--- a/lib/xlsx/xform/drawing/shape/sp-xform.js
+++ b/lib/xlsx/xform/drawing/shape/sp-xform.js
@@ -72,11 +72,18 @@ class SpXform extends BaseXform {
     }
     switch (name) {
       case this.tag:
-        this.model.props = {
-          ...(this.map['xdr:style'].model.fill ? {fill: this.map['xdr:style'].model.fill} : {}),
-          ...(this.map['xdr:style'].model.outline ? {outline: this.map['xdr:style'].model.outline} : {}),
-          ...this.map['xdr:spPr'].model,
-        };
+        if (this.map['xdr:style'].model) {
+          this.model.props = {
+            ...(this.map['xdr:style'].model.fill ? {fill: this.map['xdr:style'].model.fill} : {}),
+            ...(this.map['xdr:style'].model.outline ? {outline: this.map['xdr:style'].model.outline} : {}),
+          };
+        }
+        if (this.map['xdr:spPr'].model) {
+          this.model.props = {
+            ...this.model.props,
+            ...this.map['xdr:spPr'].model,
+          };
+        }
         if (this.map['xdr:txBody'].model) {
           this.model.props.textBody = this.map['xdr:txBody'].model;
         }

--- a/lib/xlsx/xform/drawing/shape/sp-xform.js
+++ b/lib/xlsx/xform/drawing/shape/sp-xform.js
@@ -79,6 +79,9 @@ class SpXform extends BaseXform {
         if (this.map['xdr:txBody'].model) {
           this.model.textBody = this.map['xdr:txBody'].model;
         }
+        if (this.map['xdr:spPr'].noFill) {
+          delete this.model.fill;
+        }
         return false;
       default:
         return true;

--- a/lib/xlsx/xform/drawing/shape/sp-xform.js
+++ b/lib/xlsx/xform/drawing/shape/sp-xform.js
@@ -1,5 +1,5 @@
-const BaseXform = require('../base-xform');
-const StaticXform = require('../static-xform');
+const BaseXform = require('../../base-xform');
+const StaticXform = require('../../static-xform');
 
 const NvSpPrXform = require('./nv-sp-pr-xform');
 const SpPrXform = require('./sp-pr-xform');

--- a/lib/xlsx/xform/drawing/shape/sp-xform.js
+++ b/lib/xlsx/xform/drawing/shape/sp-xform.js
@@ -1,8 +1,8 @@
 const BaseXform = require('../../base-xform');
-const StaticXform = require('../../static-xform');
 
 const NvSpPrXform = require('./nv-sp-pr-xform');
 const SpPrXform = require('./sp-pr-xform');
+const StyleXform = require('./style-xform');
 
 // DocumentFormat.OpenXml.Drawing.Spreadsheet.Shape
 class SpXform extends BaseXform {
@@ -12,7 +12,7 @@ class SpXform extends BaseXform {
     this.map = {
       'xdr:nvSpPr': new NvSpPrXform(),
       'xdr:spPr': new SpPrXform(),
-      'xdr:style': new StaticXform(styleJSON),
+      'xdr:style': new StyleXform(),
     };
   }
 
@@ -68,6 +68,8 @@ class SpXform extends BaseXform {
     switch (name) {
       case this.tag:
         this.mergeModel({
+          ...(this.map['xdr:style'].model.fill ? {fill: this.map['xdr:style'].model.fill} : {}),
+          ...(this.map['xdr:style'].model.outline ? {outline: this.map['xdr:style'].model.outline} : {}),
           ...this.map['xdr:spPr'].model,
         });
         return false;
@@ -76,68 +78,5 @@ class SpXform extends BaseXform {
     }
   }
 }
-
-const shadeJSON = {
-  tag: 'a:shade',
-  $: {val: '15000'},
-};
-
-const lnRefJSON = {
-  tag: 'a:lnRef',
-  $: {idx: '2'},
-  c: [
-    {
-      tag: 'a:schemeClr',
-      $: {val: 'accent1'},
-      c: [shadeJSON],
-    },
-  ],
-};
-
-const fillRefJSON = {
-  tag: 'a:fillRef',
-  $: {idx: '1'},
-  c: [
-    {
-      tag: 'a:schemeClr',
-      $: {val: 'accent1'},
-    },
-  ],
-};
-
-const effectRefJSON = {
-  tag: 'a:effectRef',
-  $: {idx: '0'},
-  c: [
-    {
-      tag: 'a:schemeClr',
-      $: {val: 'accent1'},
-    },
-  ],
-};
-
-const fontRefJSON = {
-  tag: 'a:fontRef',
-  $: {idx: 'minor'},
-  c: [
-    {
-      tag: 'a:schemeClr',
-      $: {val: 'lt1'},
-    },
-  ],
-};
-
-const styleJSON = {
-  tag: 'xdr:style',
-  c: [lnRefJSON, fillRefJSON, effectRefJSON, fontRefJSON],
-};
-// <xdr:txBody>
-// <a:bodyPr vertOverflow="clip" horzOverflow="clip" rtlCol="0" anchor="t"/>
-// <a:lstStyle/>
-// <a:p>
-//   <a:pPr algn="l"/>
-//   <a:endParaRPr lang="en-US" sz="1100"/>
-// </a:p>
-// </xdr:txBody>
 
 module.exports = SpXform;

--- a/lib/xlsx/xform/drawing/shape/style-matrix-reference-type-xform.js
+++ b/lib/xlsx/xform/drawing/shape/style-matrix-reference-type-xform.js
@@ -1,0 +1,78 @@
+const BaseXform = require('../../base-xform');
+
+// DocumentFormat.OpenXml.Drawing.StyleMatrixReferenceType
+class StyleMatrixReferenceTypeXform extends BaseXform {
+  constructor(tagName) {
+    super();
+
+    this.map = {};
+    this.tagName = tagName;
+  }
+
+  get tag() {
+    return this.tagName;
+  }
+
+  idx() {
+    switch (this.tagName) {
+      case 'a:lnRef':
+        return 2;
+      case 'a:fillRef':
+        return 1;
+      default:
+        // do not know when to come here
+        return 0;
+    }
+  }
+
+  render(xmlStream) {
+    xmlStream.openNode(this.tag, {idx: this.idx()});
+    xmlStream.leafNode('a:schemeClr', {val: 'accent1'});
+    xmlStream.closeNode();
+  }
+
+  parseOpen(node) {
+    if (this.parser) {
+      this.parser.parseOpen(node);
+      return true;
+    }
+
+    switch (node.name) {
+      case this.tag:
+        this.model = {};
+        break;
+      case 'a:schemeClr':
+        this.model.theme = node.attributes.val;
+        break;
+      case 'a:srgbClr':
+        this.model.rgb = node.attributes.val;
+        break;
+      default:
+        this.parser = this.map[node.name];
+        if (this.parser) {
+          this.parser.parseOpen(node);
+        }
+        break;
+    }
+    return true;
+  }
+
+  parseText() {}
+
+  parseClose(name) {
+    if (this.parser) {
+      if (!this.parser.parseClose(name)) {
+        this.parser = undefined;
+      }
+      return true;
+    }
+    switch (name) {
+      case this.tag:
+        return false;
+      default:
+        return true;
+    }
+  }
+}
+
+module.exports = StyleMatrixReferenceTypeXform;

--- a/lib/xlsx/xform/drawing/shape/style-xform.js
+++ b/lib/xlsx/xform/drawing/shape/style-xform.js
@@ -1,0 +1,101 @@
+const BaseXform = require('../../base-xform');
+const StaticXform = require('../../static-xform');
+const StyleMatrixReferenceTypeXform = require('./style-matrix-reference-type-xform');
+
+// DocumentFormat.OpenXml.Drawing.Spreadsheet.ShapeStyle
+class StyleXform extends BaseXform {
+  constructor() {
+    super();
+
+    this.map = {
+      'a:lnRef': new StyleMatrixReferenceTypeXform('a:lnRef'),
+      'a:fillRef': new StyleMatrixReferenceTypeXform('a:fillRef'),
+      'a:effectRef': new StaticXform(effectRefJSON),
+      'a:fontRef': new StaticXform(fontRefJSON),
+    };
+  }
+
+  get tag() {
+    return 'xdr:style';
+  }
+
+  render(xmlStream, shape) {
+    xmlStream.openNode(this.tag);
+    // Must care about the order
+    this.map['a:lnRef'].render(xmlStream);
+    this.map['a:fillRef'].render(xmlStream);
+    this.map['a:effectRef'].render(xmlStream, shape.effectRef);
+    this.map['a:fontRef'].render(xmlStream, shape.fontRef);
+    xmlStream.closeNode();
+  }
+
+  parseOpen(node) {
+    if (this.parser) {
+      this.parser.parseOpen(node);
+      return true;
+    }
+
+    switch (node.name) {
+      case this.tag:
+        this.model = {};
+        break;
+      default:
+        this.parser = this.map[node.name];
+        if (this.parser) {
+          this.parser.parseOpen(node);
+        }
+        break;
+    }
+    return true;
+  }
+
+  parseText() {}
+
+  parseClose(name) {
+    if (this.parser) {
+      if (!this.parser.parseClose(name)) {
+        this.parser = undefined;
+      }
+      return true;
+    }
+    switch (name) {
+      case this.tag:
+        if (this.map['a:lnRef'].model) {
+          this.model.outline = this.map['a:lnRef'].model;
+        }
+        if (this.map['a:fillRef'].model) {
+          this.model.fill = {
+            type: 'solid',
+            color: this.map['a:fillRef'].model,
+          };
+        }
+        return false;
+      default:
+        return true;
+    }
+  }
+}
+
+const effectRefJSON = {
+  tag: 'a:effectRef',
+  $: {idx: '0'},
+  c: [
+    {
+      tag: 'a:schemeClr',
+      $: {val: 'accent1'},
+    },
+  ],
+};
+
+const fontRefJSON = {
+  tag: 'a:fontRef',
+  $: {idx: 'minor'},
+  c: [
+    {
+      tag: 'a:schemeClr',
+      $: {val: 'lt1'},
+    },
+  ],
+};
+
+module.exports = StyleXform;

--- a/lib/xlsx/xform/drawing/shape/tx-body-xform.js
+++ b/lib/xlsx/xform/drawing/shape/tx-body-xform.js
@@ -17,12 +17,15 @@ class TxBodyXform extends BaseXform {
 
   render(xmlStream, textBody) {
     xmlStream.openNode(this.tag);
-    xmlStream.leafNode('a:bodyPr', {
+    xmlStream.openNode('a:bodyPr', {
       vertOverflow: 'clip',
       horzOverflow: 'clip',
       rtlCol: 0,
-      anchor: 't',
     });
+    if (textBody.vertAlign) {
+      xmlStream.addAttribute('anchor', textBody.vertAlign);
+    }
+    xmlStream.closeNode();
     xmlStream.leafNode('a:lstStyle');
     textBody.paragraphs.forEach(p => {
       this.map['a:p'].render(xmlStream, p);
@@ -39,6 +42,11 @@ class TxBodyXform extends BaseXform {
     switch (node.name) {
       case this.tag:
         this.model = {paragraphs: []};
+        break;
+      case 'a:bodyPr':
+        if (node.attributes.anchor) {
+          this.model.vertAlign = node.attributes.anchor;
+        }
         break;
       default:
         this.parser = this.map[node.name];

--- a/lib/xlsx/xform/drawing/shape/tx-body-xform.js
+++ b/lib/xlsx/xform/drawing/shape/tx-body-xform.js
@@ -1,0 +1,78 @@
+const BaseXform = require('../../base-xform');
+const ParagraphXform = require('./p-xform');
+
+// DocumentFormat.OpenXml.Drawing.Spreadsheet.TextBody
+class TxBodyXform extends BaseXform {
+  constructor() {
+    super();
+
+    this.map = {
+      'a:p': new ParagraphXform(),
+    };
+  }
+
+  get tag() {
+    return 'xdr:txBody';
+  }
+
+  render(xmlStream, textBody) {
+    xmlStream.openNode(this.tag);
+    xmlStream.leafNode('a:bodyPr', {
+      vertOverflow: 'clip',
+      horzOverflow: 'clip',
+      rtlCol: 0,
+      anchor: 't',
+    });
+    xmlStream.leafNode('a:lstStyle');
+    textBody.paragraphs.forEach(p => {
+      this.map['a:p'].render(xmlStream, p);
+    });
+    xmlStream.closeNode();
+  }
+
+  parseOpen(node) {
+    if (this.parser) {
+      this.parser.parseOpen(node);
+      return true;
+    }
+
+    switch (node.name) {
+      case this.tag:
+        this.model = {paragraphs: []};
+        break;
+      default:
+        this.parser = this.map[node.name];
+        if (this.parser) {
+          this.parser.parseOpen(node);
+        }
+        break;
+    }
+    return true;
+  }
+
+  parseText(text) {
+    if (this.parser) {
+      this.parser.parseText(text);
+    }
+  }
+
+  parseClose(name) {
+    if (this.parser) {
+      if (!this.parser.parseClose(name)) {
+        if (name === 'a:p') {
+          this.model.paragraphs.push(this.parser.model);
+        }
+        this.parser = undefined;
+      }
+      return true;
+    }
+    switch (name) {
+      case this.tag:
+        return false;
+      default:
+        return true;
+    }
+  }
+}
+
+module.exports = TxBodyXform;

--- a/lib/xlsx/xform/drawing/sp-pr-xform.js
+++ b/lib/xlsx/xform/drawing/sp-pr-xform.js
@@ -1,25 +1,26 @@
 const BaseXform = require('../base-xform');
-const CNvPrXform = require('./c-nv-pr-xform');
-const CNvPicPrXform = require('./c-nv-pic-pr-xform');
+const XfrmXform = require('./xfrm-xform');
+const PrstGeomXform = require('./prst-geom-xform');
 
-class NvPicPrXform extends BaseXform {
+// DocumentFormat.OpenXml.Drawing.Spreadsheet.ShapeProperties
+class SpPrXform extends BaseXform {
   constructor() {
     super();
 
     this.map = {
-      'xdr:cNvPr': new CNvPrXform(true),
-      'xdr:cNvPicPr': new CNvPicPrXform(),
+      'a:xfrm': new XfrmXform(),
+      'a:prstGeom': new PrstGeomXform(),
     };
   }
 
   get tag() {
-    return 'xdr:nvPicPr';
+    return 'xdr:spPr';
   }
 
-  render(xmlStream, model) {
+  render(xmlStream, shape) {
     xmlStream.openNode(this.tag);
-    this.map['xdr:cNvPr'].render(xmlStream, model);
-    this.map['xdr:cNvPicPr'].render(xmlStream, model);
+    this.map['a:xfrm'].render(xmlStream, shape);
+    this.map['a:prstGeom'].render(xmlStream, shape);
     xmlStream.closeNode();
   }
 
@@ -31,7 +32,7 @@ class NvPicPrXform extends BaseXform {
 
     switch (node.name) {
       case this.tag:
-        this.reset();
+        this.model = {};
         break;
       default:
         this.parser = this.map[node.name];
@@ -54,7 +55,10 @@ class NvPicPrXform extends BaseXform {
     }
     switch (name) {
       case this.tag:
-        this.model = this.map['xdr:cNvPr'].model;
+        this.mergeModel({
+          ...this.map['a:xfrm'].model,
+          ...this.map['a:prstGeom'].model,
+        });
         return false;
       default:
         return true;
@@ -62,4 +66,4 @@ class NvPicPrXform extends BaseXform {
   }
 }
 
-module.exports = NvPicPrXform;
+module.exports = SpPrXform;

--- a/lib/xlsx/xform/drawing/sp-xform.js
+++ b/lib/xlsx/xform/drawing/sp-xform.js
@@ -1,0 +1,143 @@
+const BaseXform = require('../base-xform');
+const StaticXform = require('../static-xform');
+
+const NvSpPrXform = require('./nv-sp-pr-xform');
+const SpPrXform = require('./sp-pr-xform');
+
+// DocumentFormat.OpenXml.Drawing.Spreadsheet.Shape
+class SpXform extends BaseXform {
+  constructor() {
+    super();
+
+    this.map = {
+      'xdr:nvSpPr': new NvSpPrXform(),
+      'xdr:spPr': new SpPrXform(),
+      'xdr:style': new StaticXform(styleJSON),
+    };
+  }
+
+  get tag() {
+    return 'xdr:sp';
+  }
+
+  prepare(model, options) {
+    model.index = options.index + 1;
+  }
+
+  render(xmlStream, model) {
+    xmlStream.openNode(this.tag, {macro: '', textlink: ''});
+
+    this.map['xdr:nvSpPr'].render(xmlStream, model);
+    this.map['xdr:spPr'].render(xmlStream, model);
+    this.map['xdr:style'].render(xmlStream, model);
+
+    xmlStream.closeNode();
+  }
+
+  parseOpen(node) {
+    if (this.parser) {
+      this.parser.parseOpen(node);
+      return true;
+    }
+    switch (node.name) {
+      case this.tag:
+        break;
+      default:
+        this.parser = this.map[node.name];
+        if (this.parser) {
+          this.parser.parseOpen(node);
+        }
+        break;
+    }
+    return true;
+  }
+
+  parseText(text) {
+    if (this.parser) {
+      this.parser.parseText(text);
+    }
+  }
+
+  parseClose(name) {
+    if (this.parser) {
+      if (!this.parser.parseClose(name)) {
+        this.parser = undefined;
+      }
+      return true;
+    }
+    switch (name) {
+      case this.tag:
+        this.mergeModel({
+          ...this.map['xdr:spPr'].model,
+        });
+        return false;
+      default:
+        return true;
+    }
+  }
+}
+
+const shadeJSON = {
+  tag: 'a:shade',
+  $: {val: '15000'},
+};
+
+const lnRefJSON = {
+  tag: 'a:lnRef',
+  $: {idx: '2'},
+  c: [
+    {
+      tag: 'a:schemeClr',
+      $: {val: 'accent1'},
+      c: [shadeJSON],
+    },
+  ],
+};
+
+const fillRefJSON = {
+  tag: 'a:fillRef',
+  $: {idx: '1'},
+  c: [
+    {
+      tag: 'a:schemeClr',
+      $: {val: 'accent1'},
+    },
+  ],
+};
+
+const effectRefJSON = {
+  tag: 'a:effectRef',
+  $: {idx: '0'},
+  c: [
+    {
+      tag: 'a:schemeClr',
+      $: {val: 'accent1'},
+    },
+  ],
+};
+
+const fontRefJSON = {
+  tag: 'a:fontRef',
+  $: {idx: 'minor'},
+  c: [
+    {
+      tag: 'a:schemeClr',
+      $: {val: 'lt1'},
+    },
+  ],
+};
+
+const styleJSON = {
+  tag: 'xdr:style',
+  c: [lnRefJSON, fillRefJSON, effectRefJSON, fontRefJSON],
+};
+// <xdr:txBody>
+// <a:bodyPr vertOverflow="clip" horzOverflow="clip" rtlCol="0" anchor="t"/>
+// <a:lstStyle/>
+// <a:p>
+//   <a:pPr algn="l"/>
+//   <a:endParaRPr lang="en-US" sz="1100"/>
+// </a:p>
+// </xdr:txBody>
+
+module.exports = SpXform;

--- a/lib/xlsx/xform/drawing/two-cell-anchor-xform.js
+++ b/lib/xlsx/xform/drawing/two-cell-anchor-xform.js
@@ -2,8 +2,8 @@ const BaseCellAnchorXform = require('./base-cell-anchor-xform');
 const StaticXform = require('../static-xform');
 
 const CellPositionXform = require('./cell-position-xform');
-const PicXform = require('./pic-xform');
-const SpXform = require('./sp-xform');
+const PicXform = require('./picture/pic-xform');
+const SpXform = require('./shape/sp-xform');
 
 class TwoCellAnchorXform extends BaseCellAnchorXform {
   constructor() {

--- a/lib/xlsx/xform/drawing/two-cell-anchor-xform.js
+++ b/lib/xlsx/xform/drawing/two-cell-anchor-xform.js
@@ -3,6 +3,7 @@ const StaticXform = require('../static-xform');
 
 const CellPositionXform = require('./cell-position-xform');
 const PicXform = require('./pic-xform');
+const SpXform = require('./sp-xform');
 
 class TwoCellAnchorXform extends BaseCellAnchorXform {
   constructor() {
@@ -12,6 +13,7 @@ class TwoCellAnchorXform extends BaseCellAnchorXform {
       'xdr:from': new CellPositionXform({tag: 'xdr:from'}),
       'xdr:to': new CellPositionXform({tag: 'xdr:to'}),
       'xdr:pic': new PicXform(),
+      'xdr:sp': new SpXform(),
       'xdr:clientData': new StaticXform({tag: 'xdr:clientData'}),
     };
   }
@@ -21,7 +23,12 @@ class TwoCellAnchorXform extends BaseCellAnchorXform {
   }
 
   prepare(model, options) {
-    this.map['xdr:pic'].prepare(model.picture, options);
+    if (model.picture) {
+      this.map['xdr:pic'].prepare(model.picture, options);
+    }
+    if (model.shape) {
+      this.map['xdr:sp'].prepare(model.shape, options);
+    }
   }
 
   render(xmlStream, model) {
@@ -29,7 +36,12 @@ class TwoCellAnchorXform extends BaseCellAnchorXform {
 
     this.map['xdr:from'].render(xmlStream, model.range.tl);
     this.map['xdr:to'].render(xmlStream, model.range.br);
-    this.map['xdr:pic'].render(xmlStream, model.picture);
+    if (model.picture) {
+      this.map['xdr:pic'].render(xmlStream, model.picture);
+    }
+    if (model.shape) {
+      this.map['xdr:sp'].render(xmlStream, model.shape);
+    }
     this.map['xdr:clientData'].render(xmlStream, {});
 
     xmlStream.closeNode();
@@ -47,6 +59,7 @@ class TwoCellAnchorXform extends BaseCellAnchorXform {
         this.model.range.tl = this.map['xdr:from'].model;
         this.model.range.br = this.map['xdr:to'].model;
         this.model.picture = this.map['xdr:pic'].model;
+        this.model.shape = this.map['xdr:sp'].model;
         return false;
       default:
         // could be some unrecognised tags

--- a/lib/xlsx/xform/drawing/xfrm-xform.js
+++ b/lib/xlsx/xform/drawing/xfrm-xform.js
@@ -11,7 +11,7 @@ class XfrmXform extends BaseXform {
     return 'a:xfrm';
   }
 
-  render(xmlStream, shape) {
+  render(xmlStream) {
     xmlStream.openNode(this.tag);
     xmlStream.leafNode('a:off', {x: 0, y: 0});
     xmlStream.leafNode('a:ext', {cx: 0, cy: 0});

--- a/lib/xlsx/xform/drawing/xfrm-xform.js
+++ b/lib/xlsx/xform/drawing/xfrm-xform.js
@@ -1,25 +1,20 @@
 const BaseXform = require('../base-xform');
-const CNvPrXform = require('./c-nv-pr-xform');
-const CNvPicPrXform = require('./c-nv-pic-pr-xform');
 
-class NvPicPrXform extends BaseXform {
+// DocumentFormat.OpenXml.Drawing.Transform2D
+class XfrmXform extends BaseXform {
   constructor() {
     super();
-
-    this.map = {
-      'xdr:cNvPr': new CNvPrXform(true),
-      'xdr:cNvPicPr': new CNvPicPrXform(),
-    };
+    this.map = {};
   }
 
   get tag() {
-    return 'xdr:nvPicPr';
+    return 'a:xfrm';
   }
 
-  render(xmlStream, model) {
+  render(xmlStream, shape) {
     xmlStream.openNode(this.tag);
-    this.map['xdr:cNvPr'].render(xmlStream, model);
-    this.map['xdr:cNvPicPr'].render(xmlStream, model);
+    xmlStream.leafNode('a:off', {x: 0, y: 0});
+    xmlStream.leafNode('a:ext', {cx: 0, cy: 0});
     xmlStream.closeNode();
   }
 
@@ -28,10 +23,8 @@ class NvPicPrXform extends BaseXform {
       this.parser.parseOpen(node);
       return true;
     }
-
     switch (node.name) {
       case this.tag:
-        this.reset();
         break;
       default:
         this.parser = this.map[node.name];
@@ -54,7 +47,6 @@ class NvPicPrXform extends BaseXform {
     }
     switch (name) {
       case this.tag:
-        this.model = this.map['xdr:cNvPr'].model;
         return false;
       default:
         return true;
@@ -62,4 +54,4 @@ class NvPicPrXform extends BaseXform {
   }
 }
 
-module.exports = NvPicPrXform;
+module.exports = XfrmXform;

--- a/lib/xlsx/xform/drawing/xfrm-xform.js
+++ b/lib/xlsx/xform/drawing/xfrm-xform.js
@@ -11,8 +11,12 @@ class XfrmXform extends BaseXform {
     return 'a:xfrm';
   }
 
-  render(xmlStream) {
-    xmlStream.openNode(this.tag);
+  render(xmlStream, model) {
+    xmlStream.openNode(this.tag, {
+      rot: model.rotation ? model.rotation * 60000 : undefined,
+      flipH: model.horizontalFlip ? '1' : undefined,
+      flipV: model.verticalFlip ? '1' : undefined,
+    });
     xmlStream.leafNode('a:off', {x: 0, y: 0});
     xmlStream.leafNode('a:ext', {cx: 0, cy: 0});
     xmlStream.closeNode();
@@ -25,6 +29,11 @@ class XfrmXform extends BaseXform {
     }
     switch (node.name) {
       case this.tag:
+        this.model = {
+          rotation: node.attributes.rot ? parseInt(node.attributes.rot, 10) / 60000 : undefined,
+          horizontalFlip: node.attributes.flipH ? node.attributes.flipH === '1' : undefined,
+          verticalFlip: node.attributes.flipV ? node.attributes.flipV === '1' : undefined,
+        };
         break;
       default:
         this.parser = this.map[node.name];

--- a/lib/xlsx/xform/sheet/worksheet-xform.js
+++ b/lib/xlsx/xform/sheet/worksheet-xform.js
@@ -191,6 +191,25 @@ class WorkSheetXform extends BaseXform {
       });
     }
 
+    const getDrawingModel = () => {
+      if (!model.drawing) {
+        const drawing = {
+          rId: nextRid(rels),
+          name: `drawing${++options.drawingsCount}`,
+          anchors: [],
+          rels: [],
+        };
+        options.drawings.push(drawing);
+        rels.push({
+          Id: drawing.rId,
+          Type: 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/drawing',
+          Target: `../drawings/${drawing.name}.xml`,
+        });
+        model.drawing = drawing;
+      }
+      return model.drawing;
+    };
+
     const drawingRelsHash = [];
     let bookImage;
     model.media.forEach(medium => {
@@ -207,22 +226,8 @@ class WorkSheetXform extends BaseXform {
         };
         model.image = options.media[medium.imageId];
       } else if (medium.type === 'image') {
-        let {drawing} = model;
         bookImage = options.media[medium.imageId];
-        if (!drawing) {
-          drawing = model.drawing = {
-            rId: nextRid(rels),
-            name: `drawing${++options.drawingsCount}`,
-            anchors: [],
-            rels: [],
-          };
-          options.drawings.push(drawing);
-          rels.push({
-            Id: drawing.rId,
-            Type: 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/drawing',
-            Target: `../drawings/${drawing.name}.xml`,
-          });
-        }
+        const drawing = getDrawingModel();
         let rIdImage =
           this.preImageId === medium.imageId ? drawingRelsHash[medium.imageId] : drawingRelsHash[drawing.rels.length];
         if (!rIdImage) {
@@ -258,6 +263,15 @@ class WorkSheetXform extends BaseXform {
         this.preImageId = medium.imageId;
         drawing.anchors.push(anchor);
       }
+    });
+
+    model.shapes.forEach(shape => {
+      const drawing = getDrawingModel();
+      const anchor = {
+        shape: shape.props,
+        range: shape.range,
+      };
+      drawing.anchors.push(anchor);
     });
 
     // prepare tables
@@ -494,6 +508,7 @@ class WorkSheetXform extends BaseXform {
     this.map.conditionalFormatting.reconcile(model.conditionalFormattings, options);
 
     model.media = [];
+    model.shapes = [];
     if (model.drawing) {
       const drawingRel = rels[model.drawing.rId];
       const match = drawingRel.Target.match(/\/drawings\/([a-zA-Z0-9]+)[.][a-zA-Z]{3,4}$/);
@@ -509,6 +524,12 @@ class WorkSheetXform extends BaseXform {
               hyperlinks: anchor.picture.hyperlinks,
             };
             model.media.push(image);
+          } else if (anchor.shape) {
+            const shape = {
+              props: anchor.shape,
+              range: anchor.range,
+            };
+            model.shapes.push(shape);
           }
         });
       }

--- a/lib/xlsx/xform/sheet/worksheet-xform.js
+++ b/lib/xlsx/xform/sheet/worksheet-xform.js
@@ -210,6 +210,18 @@ class WorkSheetXform extends BaseXform {
       return model.drawing;
     };
 
+    const addHyperlink = (hyperlink, drawing) => {
+      const rId = nextRid(drawing.rels);
+      drawingRelsHash[drawing.rels.length] = rId;
+      drawing.rels.push({
+        Id: rId,
+        Type: RelType.Hyperlink,
+        Target: hyperlink,
+        TargetMode: 'External',
+      });
+      return rId;
+    };
+
     const drawingRelsHash = [];
     let bookImage;
     model.media.forEach(medium => {
@@ -247,18 +259,11 @@ class WorkSheetXform extends BaseXform {
           range: medium.range,
         };
         if (medium.hyperlinks && medium.hyperlinks.hyperlink) {
-          const rIdHyperLink = nextRid(drawing.rels);
-          drawingRelsHash[drawing.rels.length] = rIdHyperLink;
+          const rId = addHyperlink(medium.hyperlinks.hyperlink, drawing);
           anchor.picture.hyperlinks = {
             tooltip: medium.hyperlinks.tooltip,
-            rId: rIdHyperLink,
+            rId,
           };
-          drawing.rels.push({
-            Id: rIdHyperLink,
-            Type: RelType.Hyperlink,
-            Target: medium.hyperlinks.hyperlink,
-            TargetMode: 'External',
-          });
         }
         this.preImageId = medium.imageId;
         drawing.anchors.push(anchor);
@@ -268,9 +273,18 @@ class WorkSheetXform extends BaseXform {
     model.shapes.forEach(shape => {
       const drawing = getDrawingModel();
       const anchor = {
-        shape: shape.props,
+        shape: {
+          props: shape.props,
+        },
         range: shape.range,
       };
+      if (shape.hyperlinks && shape.hyperlinks.hyperlink) {
+        const rId = addHyperlink(shape.hyperlinks.hyperlink, drawing);
+        anchor.shape.hyperlinks = {
+          tooltip: shape.hyperlinks.tooltip,
+          rId,
+        };
+      }
       drawing.anchors.push(anchor);
     });
 
@@ -526,8 +540,9 @@ class WorkSheetXform extends BaseXform {
             model.media.push(image);
           } else if (anchor.shape) {
             const shape = {
-              props: anchor.shape,
+              props: anchor.shape.props,
               range: anchor.range,
+              hyperlinks: anchor.shape.hyperlinks,
             };
             model.shapes.push(shape);
           }

--- a/lib/xlsx/xlsx.js
+++ b/lib/xlsx/xlsx.js
@@ -101,7 +101,7 @@ class XLSX {
           return o;
         }, {});
         (drawing.anchors || []).forEach(anchor => {
-          const hyperlinks = anchor.picture && anchor.picture.hyperlinks;
+          const hyperlinks = (anchor.picture && anchor.picture.hyperlinks) || (anchor.shape && anchor.shape.hyperlinks);
           if (hyperlinks && drawingOptions.rels[hyperlinks.rId]) {
             hyperlinks.hyperlink = drawingOptions.rels[hyperlinks.rId].Target;
             delete hyperlinks.rId;

--- a/spec/integration/workbook/shapes.spec.js
+++ b/spec/integration/workbook/shapes.spec.js
@@ -145,7 +145,10 @@ describe('Parsing text body', () => {
               text: 'foo',
               font: {size: 15, bold: true, italic: true, underline: 'sng'},
             },
-            {text: 'bar'},
+            {
+              text: 'bar',
+              font: {color: {theme: 'accent1'}},
+            },
           ],
           alignment: 'ctr',
         },

--- a/spec/integration/workbook/shapes.spec.js
+++ b/spec/integration/workbook/shapes.spec.js
@@ -13,7 +13,10 @@ describe('Workbook', () => {
       let wb2;
       let ws2;
 
-      ws.addShape({type: 'line'}, 'B2:D6');
+      ws.addShape(
+        {type: 'line', fill: {type: 'solid', color: {theme: 'accent6'}}},
+        'B2:D6'
+      );
 
       return wb.xlsx
         .writeFile(TEST_XLSX_FILE_NAME)
@@ -29,6 +32,10 @@ describe('Workbook', () => {
 
           const shape = shapes[0];
           expect(shape.props.type).to.equal('line');
+          expect(shape.props.fill).to.deep.equal({
+            type: 'solid',
+            color: {theme: 'accent6'},
+          });
         });
     });
 
@@ -62,6 +69,7 @@ describe('Workbook', () => {
           const shape = shapes[0];
           expect(shape.range.editAs).to.equal('oneCell');
           expect(shape.props.type).to.equal('rect');
+          expect(shape.props.fill).to.undefined();
         });
     });
   });

--- a/spec/integration/workbook/shapes.spec.js
+++ b/spec/integration/workbook/shapes.spec.js
@@ -139,7 +139,16 @@ describe('Parsing text body', () => {
   it('object', () => {
     const obj = {
       paragraphs: [
-        {runs: [{text: 'foo'}, {text: 'bar'}], alignment: 'ctr'},
+        {
+          runs: [
+            {
+              text: 'foo',
+              font: {size: 15, bold: true, italic: true, underline: 'sng'},
+            },
+            {text: 'bar'},
+          ],
+          alignment: 'ctr',
+        },
         {runs: [{text: 'baz'}, {text: 'qux'}]},
       ],
       vertAlign: 'b',

--- a/spec/integration/workbook/shapes.spec.js
+++ b/spec/integration/workbook/shapes.spec.js
@@ -14,7 +14,11 @@ describe('Workbook', () => {
       let ws2;
 
       ws.addShape(
-        {type: 'line', fill: {type: 'solid', color: {theme: 'accent6'}}},
+        {
+          type: 'line',
+          fill: {type: 'solid', color: {theme: 'accent6'}},
+          outline: {weight: 30000, color: {theme: 'accent1'}},
+        },
         'B2:D6'
       );
 
@@ -35,6 +39,10 @@ describe('Workbook', () => {
           expect(shape.props.fill).to.deep.equal({
             type: 'solid',
             color: {theme: 'accent6'},
+          });
+          expect(shape.props.outline).to.deep.equal({
+            weight: 30000,
+            color: {theme: 'accent1'},
           });
         });
     });

--- a/spec/integration/workbook/shapes.spec.js
+++ b/spec/integration/workbook/shapes.spec.js
@@ -46,7 +46,7 @@ describe('Workbook', () => {
       let ws2;
 
       ws.addShape(
-        {type: 'rect'},
+        {type: 'rect', fill: {type: 'solid', color: {rgb: 'AABBCC'}}},
         {
           tl: {col: 0.1125, row: 0.4},
           br: {col: 2.101046875, row: 3.4},
@@ -69,7 +69,10 @@ describe('Workbook', () => {
           const shape = shapes[0];
           expect(shape.range.editAs).to.equal('oneCell');
           expect(shape.props.type).to.equal('rect');
-          expect(shape.props.fill).to.undefined();
+          expect(shape.props.fill).to.deep.equal({
+            type: 'solid',
+            color: {rgb: 'AABBCC'},
+          });
         });
     });
   });

--- a/spec/integration/workbook/shapes.spec.js
+++ b/spec/integration/workbook/shapes.spec.js
@@ -1,0 +1,68 @@
+const ExcelJS = verquire('exceljs');
+
+const TEST_XLSX_FILE_NAME = './spec/out/wb.test.xlsx';
+
+// =============================================================================
+// Tests
+
+describe('Workbook', () => {
+  describe('Shapes', () => {
+    it('stores shape', () => {
+      const wb = new ExcelJS.Workbook();
+      const ws = wb.addWorksheet('sheet');
+      let wb2;
+      let ws2;
+
+      ws.addShape({type: 'line'}, 'B2:D6');
+
+      return wb.xlsx
+        .writeFile(TEST_XLSX_FILE_NAME)
+        .then(() => {
+          wb2 = new ExcelJS.Workbook();
+          return wb2.xlsx.readFile(TEST_XLSX_FILE_NAME);
+        })
+        .then(() => {
+          ws2 = wb2.getWorksheet('sheet');
+          expect(ws2).to.not.be.undefined();
+          const shapes = ws2.getShapes();
+          expect(shapes.length).to.equal(1);
+
+          const shape = shapes[0];
+          expect(shape.props.type).to.equal('line');
+        });
+    });
+
+    it('stores shape with oneCell', () => {
+      const wb = new ExcelJS.Workbook();
+      const ws = wb.addWorksheet('sheet');
+      let wb2;
+      let ws2;
+
+      ws.addShape(
+        {type: 'rect'},
+        {
+          tl: {col: 0.1125, row: 0.4},
+          br: {col: 2.101046875, row: 3.4},
+          editAs: 'oneCell',
+        }
+      );
+
+      return wb.xlsx
+        .writeFile(TEST_XLSX_FILE_NAME)
+        .then(() => {
+          wb2 = new ExcelJS.Workbook();
+          return wb2.xlsx.readFile(TEST_XLSX_FILE_NAME);
+        })
+        .then(() => {
+          ws2 = wb2.getWorksheet('sheet');
+          expect(ws2).to.not.be.undefined();
+          const shapes = ws2.getShapes();
+          expect(shapes.length).to.equal(1);
+
+          const shape = shapes[0];
+          expect(shape.range.editAs).to.equal('oneCell');
+          expect(shape.props.type).to.equal('rect');
+        });
+    });
+  });
+});

--- a/spec/integration/workbook/shapes.spec.js
+++ b/spec/integration/workbook/shapes.spec.js
@@ -17,7 +17,13 @@ describe('Workbook', () => {
         {
           type: 'line',
           fill: {type: 'solid', color: {theme: 'accent6'}},
-          outline: {weight: 30000, color: {theme: 'accent1'}},
+          outline: {
+            weight: 30000,
+            color: {theme: 'accent1'},
+            arrow: {
+              head: {type: 'triangle', width: 'lg', length: 'med'},
+            },
+          },
         },
         'B2:D6'
       );
@@ -43,6 +49,9 @@ describe('Workbook', () => {
           expect(shape.props.outline).to.deep.equal({
             weight: 30000,
             color: {theme: 'accent1'},
+            arrow: {
+              head: {type: 'triangle', width: 'lg', length: 'med'},
+            },
           });
         });
     });
@@ -54,7 +63,10 @@ describe('Workbook', () => {
       let ws2;
 
       ws.addShape(
-        {type: 'rect', fill: {type: 'solid', color: {rgb: 'AABBCC'}}},
+        {
+          type: 'rect',
+          fill: {type: 'solid', color: {rgb: 'AABBCC'}},
+        },
         {
           tl: {col: 0.1125, row: 0.4},
           br: {col: 2.101046875, row: 3.4},

--- a/spec/integration/workbook/shapes.spec.js
+++ b/spec/integration/workbook/shapes.spec.js
@@ -97,3 +97,53 @@ describe('Workbook', () => {
     });
   });
 });
+
+describe('Parsing text body', () => {
+  function addAndGetShapeWithTextBody(textBody) {
+    const wb = new ExcelJS.Workbook();
+    const ws = wb.addWorksheet();
+    ws.addShape(
+      {
+        textBody,
+        type: 'rect',
+      },
+      'B2:D6'
+    );
+    return ws.getShapes()[0];
+  }
+
+  it('single string', () => {
+    const shape = addAndGetShapeWithTextBody('foo');
+    expect(shape.props.textBody).to.deep.equal({
+      paragraphs: [{runs: [{text: 'foo'}]}],
+    });
+  });
+  it('array of strings', () => {
+    const shape = addAndGetShapeWithTextBody(['foo', 'bar']);
+    expect(shape.props.textBody).to.deep.equal({
+      paragraphs: [{runs: [{text: 'foo'}]}, {runs: [{text: 'bar'}]}],
+    });
+  });
+  it('array of array of strings', () => {
+    const shape = addAndGetShapeWithTextBody([
+      ['foo', 'bar'],
+      ['baz', 'qux'],
+    ]);
+    expect(shape.props.textBody).to.deep.equal({
+      paragraphs: [
+        {runs: [{text: 'foo'}, {text: 'bar'}]},
+        {runs: [{text: 'baz'}, {text: 'qux'}]},
+      ],
+    });
+  });
+  it('object', () => {
+    const obj = {
+      paragraphs: [
+        {runs: [{text: 'foo'}, {text: 'bar'}]},
+        {runs: [{text: 'baz'}, {text: 'qux'}]},
+      ],
+    };
+    const shape = addAndGetShapeWithTextBody(obj);
+    expect(shape.props.textBody).to.deep.equal(obj);
+  });
+});

--- a/spec/integration/workbook/shapes.spec.js
+++ b/spec/integration/workbook/shapes.spec.js
@@ -139,9 +139,10 @@ describe('Parsing text body', () => {
   it('object', () => {
     const obj = {
       paragraphs: [
-        {runs: [{text: 'foo'}, {text: 'bar'}]},
+        {runs: [{text: 'foo'}, {text: 'bar'}], alignment: 'ctr'},
         {runs: [{text: 'baz'}, {text: 'qux'}]},
       ],
+      vertAlign: 'b',
     };
     const shape = addAndGetShapeWithTextBody(obj);
     expect(shape.props.textBody).to.deep.equal(obj);

--- a/spec/integration/workbook/shapes.spec.js
+++ b/spec/integration/workbook/shapes.spec.js
@@ -65,6 +65,8 @@ describe('Workbook', () => {
       ws.addShape(
         {
           type: 'rect',
+          rotation: 180,
+          horizontalFlip: true,
           fill: {type: 'solid', color: {rgb: 'AABBCC'}},
         },
         {
@@ -89,6 +91,8 @@ describe('Workbook', () => {
           const shape = shapes[0];
           expect(shape.range.editAs).to.equal('oneCell');
           expect(shape.props.type).to.equal('rect');
+          expect(shape.props.rotation).to.equal(180);
+          expect(shape.props.horizontalFlip).to.equal(true);
           expect(shape.props.fill).to.deep.equal({
             type: 'solid',
             color: {rgb: 'AABBCC'},

--- a/spec/unit/xlsx/xform/drawing/data/drawing.1.3.js
+++ b/spec/unit/xlsx/xform/drawing/data/drawing.1.3.js
@@ -13,6 +13,7 @@ module.exports = {
           rId: 'rId3',
         },
       },
+      shape: null,
     },
     {
       range: {
@@ -28,6 +29,7 @@ module.exports = {
       picture: {
         rId: 'rId2',
       },
+      shape: null,
     },
   ],
 };

--- a/spec/unit/xlsx/xform/drawing/data/drawing.1.4.js
+++ b/spec/unit/xlsx/xform/drawing/data/drawing.1.4.js
@@ -13,6 +13,7 @@ module.exports = {
           rId: 'rId3',
         },
       },
+      shape: null,
     },
     {
       range: {
@@ -28,6 +29,7 @@ module.exports = {
       picture: {
         rId: 'rId2',
       },
+      shape: null,
     },
   ],
 };

--- a/spec/unit/xlsx/xform/drawing/data/drawing.2.0.js
+++ b/spec/unit/xlsx/xform/drawing/data/drawing.2.0.js
@@ -26,5 +26,32 @@ module.exports = {
         },
       },
     },
+    {
+      range: {
+        tl: {
+          nativeCol: 6,
+          nativeColOff: 101600,
+          nativeRow: 12,
+          nativeRowOff: 63500,
+        },
+        br: {
+          nativeCol: 7,
+          nativeColOff: 190500,
+          nativeRow: 16,
+          nativeRowOff: 165100,
+        },
+        editAs: 'oneCell',
+      },
+      picture: null,
+      shape: {
+        type: 'ellipse',
+        fill: {
+          type: 'solid',
+          color: {
+            rgb: 'C651E9',
+          },
+        },
+      },
+    },
   ],
 };

--- a/spec/unit/xlsx/xform/drawing/data/drawing.2.0.js
+++ b/spec/unit/xlsx/xform/drawing/data/drawing.2.0.js
@@ -18,6 +18,12 @@ module.exports = {
       },
       shape: {
         type: 'rect',
+        fill: {
+          type: 'solid',
+          color: {
+            theme: 'accent6',
+          },
+        },
       },
     },
   ],

--- a/spec/unit/xlsx/xform/drawing/data/drawing.2.0.js
+++ b/spec/unit/xlsx/xform/drawing/data/drawing.2.0.js
@@ -17,11 +17,27 @@ module.exports = {
         editAs: 'oneCell',
       },
       shape: {
-        type: 'rect',
-        fill: {
-          type: 'solid',
-          color: {
-            theme: 'accent6',
+        props: {
+          type: 'rect',
+          fill: {
+            type: 'solid',
+            color: {
+              theme: 'accent6',
+            },
+          },
+          textBody: {
+            vertAlign: 'b',
+            paragraphs: [
+              {
+                alignment: 'l',
+                runs: [
+                  {
+                    font: {size: 11},
+                    text: 'Shape1',
+                  },
+                ],
+              },
+            ],
           },
         },
       },
@@ -44,11 +60,13 @@ module.exports = {
       },
       picture: null,
       shape: {
-        type: 'ellipse',
-        fill: {
-          type: 'solid',
-          color: {
-            rgb: 'C651E9',
+        props: {
+          type: 'ellipse',
+          fill: {
+            type: 'solid',
+            color: {
+              rgb: 'C651E9',
+            },
           },
         },
       },

--- a/spec/unit/xlsx/xform/drawing/data/drawing.2.0.js
+++ b/spec/unit/xlsx/xform/drawing/data/drawing.2.0.js
@@ -1,0 +1,24 @@
+module.exports = {
+  anchors: [
+    {
+      range: {
+        tl: {
+          nativeRow: 4,
+          nativeRowOff: 165100,
+          nativeCol: 1,
+          nativeColOff: 647700,
+        },
+        br: {
+          nativeRow: 10,
+          nativeRowOff: 165100,
+          nativeCol: 4,
+          nativeColOff: 508000,
+        },
+        editAs: 'oneCell',
+      },
+      shape: {
+        type: 'rect',
+      },
+    },
+  ],
+};

--- a/spec/unit/xlsx/xform/drawing/data/drawing.2.1.js
+++ b/spec/unit/xlsx/xform/drawing/data/drawing.2.1.js
@@ -20,6 +20,12 @@ module.exports = {
       shape: {
         index: 1,
         type: 'rect',
+        fill: {
+          type: 'solid',
+          color: {
+            theme: 'accent6',
+          },
+        },
       },
     },
   ],

--- a/spec/unit/xlsx/xform/drawing/data/drawing.2.1.js
+++ b/spec/unit/xlsx/xform/drawing/data/drawing.2.1.js
@@ -19,11 +19,27 @@ module.exports = {
       },
       shape: {
         index: 1,
-        type: 'rect',
-        fill: {
-          type: 'solid',
-          color: {
-            theme: 'accent6',
+        props: {
+          type: 'rect',
+          fill: {
+            type: 'solid',
+            color: {
+              theme: 'accent6',
+            },
+          },
+          textBody: {
+            vertAlign: 'b',
+            paragraphs: [
+              {
+                alignment: 'l',
+                runs: [
+                  {
+                    font: {size: 11},
+                    text: 'Shape1',
+                  },
+                ],
+              },
+            ],
           },
         },
       },
@@ -48,11 +64,13 @@ module.exports = {
       picture: null,
       shape: {
         index: 2,
-        type: 'ellipse',
-        fill: {
-          type: 'solid',
-          color: {
-            rgb: 'C651E9',
+        props: {
+          type: 'ellipse',
+          fill: {
+            type: 'solid',
+            color: {
+              rgb: 'C651E9',
+            },
           },
         },
       },

--- a/spec/unit/xlsx/xform/drawing/data/drawing.2.1.js
+++ b/spec/unit/xlsx/xform/drawing/data/drawing.2.1.js
@@ -1,0 +1,26 @@
+module.exports = {
+  anchors: [
+    {
+      anchorType: 'xdr:twoCellAnchor',
+      range: {
+        tl: {
+          nativeRow: 4,
+          nativeRowOff: 165100,
+          nativeCol: 1,
+          nativeColOff: 647700,
+        },
+        br: {
+          nativeRow: 10,
+          nativeRowOff: 165100,
+          nativeCol: 4,
+          nativeColOff: 508000,
+        },
+        editAs: 'oneCell',
+      },
+      shape: {
+        index: 1,
+        type: 'rect',
+      },
+    },
+  ],
+};

--- a/spec/unit/xlsx/xform/drawing/data/drawing.2.1.js
+++ b/spec/unit/xlsx/xform/drawing/data/drawing.2.1.js
@@ -28,5 +28,34 @@ module.exports = {
         },
       },
     },
+    {
+      anchorType: 'xdr:twoCellAnchor',
+      range: {
+        tl: {
+          nativeCol: 6,
+          nativeColOff: 101600,
+          nativeRow: 12,
+          nativeRowOff: 63500,
+        },
+        br: {
+          nativeCol: 7,
+          nativeColOff: 190500,
+          nativeRow: 16,
+          nativeRowOff: 165100,
+        },
+        editAs: 'oneCell',
+      },
+      picture: null,
+      shape: {
+        index: 2,
+        type: 'ellipse',
+        fill: {
+          type: 'solid',
+          color: {
+            rgb: 'C651E9',
+          },
+        },
+      },
+    },
   ],
 };

--- a/spec/unit/xlsx/xform/drawing/data/drawing.2.2.xml
+++ b/spec/unit/xlsx/xform/drawing/data/drawing.2.2.xml
@@ -51,6 +51,17 @@
           <a:schemeClr val="lt1"/>
         </a:fontRef>
       </xdr:style>
+      <xdr:txBody>
+        <a:bodyPr vertOverflow="clip" horzOverflow="clip" rtlCol="0" anchor="b"/>
+        <a:lstStyle/>
+        <a:p>
+          <a:pPr algn="l"/>
+          <a:r>
+            <a:rPr sz="1100"/>
+            <a:t>Shape1</a:t>
+          </a:r>
+        </a:p>
+      </xdr:txBody>
     </xdr:sp>
     <xdr:clientData/>
   </xdr:twoCellAnchor>

--- a/spec/unit/xlsx/xform/drawing/data/drawing.2.2.xml
+++ b/spec/unit/xlsx/xform/drawing/data/drawing.2.2.xml
@@ -33,6 +33,9 @@
         <a:prstGeom prst="rect">
           <a:avLst/>
         </a:prstGeom>
+        <a:solidFill>
+          <a:schemeClr val="accent6"/>
+        </a:solidFill>
       </xdr:spPr>
       <xdr:style>
         <a:lnRef idx="2">

--- a/spec/unit/xlsx/xform/drawing/data/drawing.2.2.xml
+++ b/spec/unit/xlsx/xform/drawing/data/drawing.2.2.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<xdr:wsDr xmlns:xdr="http://schemas.openxmlformats.org/drawingml/2006/spreadsheetDrawing"
+  xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+  <xdr:twoCellAnchor editAs="oneCell">
+    <xdr:from>
+      <xdr:col>1</xdr:col>
+      <xdr:colOff>647700</xdr:colOff>
+      <xdr:row>4</xdr:row>
+      <xdr:rowOff>165100</xdr:rowOff>
+    </xdr:from>
+    <xdr:to>
+      <xdr:col>4</xdr:col>
+      <xdr:colOff>508000</xdr:colOff>
+      <xdr:row>10</xdr:row>
+      <xdr:rowOff>165100</xdr:rowOff>
+    </xdr:to>
+    <xdr:sp macro="" textlink="">
+      <xdr:nvSpPr>
+        <xdr:cNvPr id="1" name="Shape 1">
+          <a:extLst>
+            <a:ext uri="{FF2B5EF4-FFF2-40B4-BE49-F238E27FC236}">
+              <a16:creationId xmlns:a16="http://schemas.microsoft.com/office/drawing/2014/main" id="{00000000-0008-0000-0000-000002000000}"/>
+            </a:ext>
+          </a:extLst>
+        </xdr:cNvPr>
+        <xdr:cNvSpPr/>
+      </xdr:nvSpPr>
+      <xdr:spPr>
+        <a:xfrm>
+          <a:off x="0" y="0"/>
+          <a:ext cx="0" cy="0"/>
+        </a:xfrm>
+        <a:prstGeom prst="rect">
+          <a:avLst/>
+        </a:prstGeom>
+      </xdr:spPr>
+      <xdr:style>
+        <a:lnRef idx="2">
+          <a:schemeClr val="accent1">
+            <a:shade val="15000"/>
+          </a:schemeClr>
+        </a:lnRef>
+        <a:fillRef idx="1">
+          <a:schemeClr val="accent1"/>
+        </a:fillRef>
+        <a:effectRef idx="0">
+          <a:schemeClr val="accent1"/>
+        </a:effectRef>
+        <a:fontRef idx="minor">
+          <a:schemeClr val="lt1"/>
+        </a:fontRef>
+      </xdr:style>
+    </xdr:sp>
+    <xdr:clientData/>
+  </xdr:twoCellAnchor>
+</xdr:wsDr>

--- a/spec/unit/xlsx/xform/drawing/data/drawing.2.2.xml
+++ b/spec/unit/xlsx/xform/drawing/data/drawing.2.2.xml
@@ -39,9 +39,7 @@
       </xdr:spPr>
       <xdr:style>
         <a:lnRef idx="2">
-          <a:schemeClr val="accent1">
-            <a:shade val="15000"/>
-          </a:schemeClr>
+          <a:schemeClr val="accent1"/>
         </a:lnRef>
         <a:fillRef idx="1">
           <a:schemeClr val="accent1"/>
@@ -94,9 +92,7 @@
       </xdr:spPr>
       <xdr:style>
         <a:lnRef idx="2">
-          <a:schemeClr val="accent1">
-            <a:shade val="15000"/>
-          </a:schemeClr>
+          <a:schemeClr val="accent1"/>
         </a:lnRef>
         <a:fillRef idx="1">
           <a:schemeClr val="accent1"/>

--- a/spec/unit/xlsx/xform/drawing/data/drawing.2.2.xml
+++ b/spec/unit/xlsx/xform/drawing/data/drawing.2.2.xml
@@ -56,4 +56,59 @@
     </xdr:sp>
     <xdr:clientData/>
   </xdr:twoCellAnchor>
+  <xdr:twoCellAnchor editAs="oneCell">
+    <xdr:from>
+      <xdr:col>6</xdr:col>
+      <xdr:colOff>101600</xdr:colOff>
+      <xdr:row>12</xdr:row>
+      <xdr:rowOff>63500</xdr:rowOff>
+    </xdr:from>
+    <xdr:to>
+      <xdr:col>7</xdr:col>
+      <xdr:colOff>190500</xdr:colOff>
+      <xdr:row>16</xdr:row>
+      <xdr:rowOff>165100</xdr:rowOff>
+    </xdr:to>
+    <xdr:sp macro="" textlink="">
+      <xdr:nvSpPr>
+        <xdr:cNvPr id="2" name="Shape 2">
+          <a:extLst>
+            <a:ext uri="{FF2B5EF4-FFF2-40B4-BE49-F238E27FC236}">
+              <a16:creationId xmlns:a16="http://schemas.microsoft.com/office/drawing/2014/main" id="{00000000-0008-0000-0000-000002000000}"/>
+            </a:ext>
+          </a:extLst>
+        </xdr:cNvPr>
+        <xdr:cNvSpPr/>
+      </xdr:nvSpPr>
+      <xdr:spPr>
+        <a:xfrm>
+          <a:off x="0" y="0"/>
+          <a:ext cx="0" cy="0"/>
+        </a:xfrm>
+        <a:prstGeom prst="ellipse">
+          <a:avLst/>
+        </a:prstGeom>
+        <a:solidFill>
+          <a:srgbClr val="C651E9"/>
+        </a:solidFill>
+      </xdr:spPr>
+      <xdr:style>
+        <a:lnRef idx="2">
+          <a:schemeClr val="accent1">
+            <a:shade val="15000"/>
+          </a:schemeClr>
+        </a:lnRef>
+        <a:fillRef idx="1">
+          <a:schemeClr val="accent1"/>
+        </a:fillRef>
+        <a:effectRef idx="0">
+          <a:schemeClr val="accent1"/>
+        </a:effectRef>
+        <a:fontRef idx="minor">
+          <a:schemeClr val="lt1"/>
+        </a:fontRef>
+      </xdr:style>
+    </xdr:sp>
+    <xdr:clientData/>
+  </xdr:twoCellAnchor>
 </xdr:wsDr>

--- a/spec/unit/xlsx/xform/drawing/data/drawing.2.3.js
+++ b/spec/unit/xlsx/xform/drawing/data/drawing.2.3.js
@@ -1,0 +1,25 @@
+module.exports = {
+  anchors: [
+    {
+      range: {
+        tl: {
+          nativeRow: 4,
+          nativeRowOff: 165100,
+          nativeCol: 1,
+          nativeColOff: 647700,
+        },
+        br: {
+          nativeRow: 10,
+          nativeRowOff: 165100,
+          nativeCol: 4,
+          nativeColOff: 508000,
+        },
+        editAs: 'oneCell',
+      },
+      picture: null,
+      shape: {
+        type: 'rect',
+      },
+    },
+  ],
+};

--- a/spec/unit/xlsx/xform/drawing/data/drawing.2.3.js
+++ b/spec/unit/xlsx/xform/drawing/data/drawing.2.3.js
@@ -27,5 +27,32 @@ module.exports = {
         },
       },
     },
+    {
+      range: {
+        tl: {
+          nativeCol: 6,
+          nativeColOff: 101600,
+          nativeRow: 12,
+          nativeRowOff: 63500,
+        },
+        br: {
+          nativeCol: 7,
+          nativeColOff: 190500,
+          nativeRow: 16,
+          nativeRowOff: 165100,
+        },
+        editAs: 'oneCell',
+      },
+      picture: null,
+      shape: {
+        type: 'ellipse',
+        fill: {
+          type: 'solid',
+          color: {
+            rgb: 'C651E9',
+          },
+        },
+      },
+    },
   ],
 };

--- a/spec/unit/xlsx/xform/drawing/data/drawing.2.3.js
+++ b/spec/unit/xlsx/xform/drawing/data/drawing.2.3.js
@@ -19,6 +19,12 @@ module.exports = {
       picture: null,
       shape: {
         type: 'rect',
+        fill: {
+          type: 'solid',
+          color: {
+            theme: 'accent6',
+          },
+        },
       },
     },
   ],

--- a/spec/unit/xlsx/xform/drawing/data/drawing.2.3.js
+++ b/spec/unit/xlsx/xform/drawing/data/drawing.2.3.js
@@ -18,15 +18,31 @@ module.exports = {
       },
       picture: null,
       shape: {
-        type: 'rect',
-        fill: {
-          type: 'solid',
-          color: {
-            theme: 'accent6',
+        props: {
+          type: 'rect',
+          fill: {
+            type: 'solid',
+            color: {
+              theme: 'accent6',
+            },
           },
-        },
-        outline: {
-          theme: 'accent1',
+          outline: {
+            theme: 'accent1',
+          },
+          textBody: {
+            vertAlign: 'b',
+            paragraphs: [
+              {
+                alignment: 'l',
+                runs: [
+                  {
+                    font: {size: 11},
+                    text: 'Shape1',
+                  },
+                ],
+              },
+            ],
+          },
         },
       },
     },
@@ -48,15 +64,17 @@ module.exports = {
       },
       picture: null,
       shape: {
-        type: 'ellipse',
-        fill: {
-          type: 'solid',
-          color: {
-            rgb: 'C651E9',
+        props: {
+          type: 'ellipse',
+          fill: {
+            type: 'solid',
+            color: {
+              rgb: 'C651E9',
+            },
           },
-        },
-        outline: {
-          theme: 'accent1',
+          outline: {
+            theme: 'accent1',
+          },
         },
       },
     },

--- a/spec/unit/xlsx/xform/drawing/data/drawing.2.3.js
+++ b/spec/unit/xlsx/xform/drawing/data/drawing.2.3.js
@@ -25,6 +25,9 @@ module.exports = {
             theme: 'accent6',
           },
         },
+        outline: {
+          theme: 'accent1',
+        },
       },
     },
     {
@@ -51,6 +54,9 @@ module.exports = {
           color: {
             rgb: 'C651E9',
           },
+        },
+        outline: {
+          theme: 'accent1',
         },
       },
     },

--- a/spec/unit/xlsx/xform/drawing/drawing-xform.spec.js
+++ b/spec/unit/xlsx/xform/drawing/drawing-xform.spec.js
@@ -27,6 +27,19 @@ const expectations = [
     tests: ['prepare', 'render', 'renderIn', 'parse', 'reconcile'],
     options,
   },
+  {
+    title: 'Drawing 2 (Shapes)',
+    create() {
+      return new DrawingXform();
+    },
+    initialModel: require('./data/drawing.2.0.js'),
+    preparedModel: require('./data/drawing.2.1.js'),
+    xml: fs.readFileSync(`${__dirname}/data/drawing.2.2.xml`).toString(),
+    parsedModel: require('./data/drawing.2.3.js'),
+    reconciledModel: require('./data/drawing.2.3.js'),
+    tests: ['prepare', 'render', 'renderIn', 'parse', 'reconcile'],
+    options,
+  },
 ];
 
 describe('DrawingXform', () => {

--- a/spec/unit/xlsx/xform/sheet/data/sheet.1.0.json
+++ b/spec/unit/xlsx/xform/sheet/data/sheet.1.0.json
@@ -72,6 +72,7 @@
     "evenFooter": "&Lexceljs&C&F&RPage &P evenHeader"
   },
   "media": [],
+  "shapes": [],
   "rowBreaks": [],
   "tables": [],
   "conditionalFormattings": []

--- a/spec/unit/xlsx/xform/sheet/data/sheet.1.1.json
+++ b/spec/unit/xlsx/xform/sheet/data/sheet.1.1.json
@@ -78,6 +78,7 @@
   ],
   "comments": [],
   "media": [],
+  "shapes": [],
   "rowBreaks": [],
   "tables": [],
   "headerFooter": {

--- a/spec/unit/xlsx/xform/sheet/data/sheet.2.0.json
+++ b/spec/unit/xlsx/xform/sheet/data/sheet.2.0.json
@@ -45,6 +45,7 @@
     "B7": { "type": "whole", "allowBlank": true, "showInputMessage": true, "showErrorMessage": true, "operator": "between", "formulae": ["1", "10"]}
   },
   "media": [],
+  "shapes": [],
   "tables": [],
   "conditionalFormattings": []
 }

--- a/spec/unit/xlsx/xform/sheet/data/sheet.2.1.json
+++ b/spec/unit/xlsx/xform/sheet/data/sheet.2.1.json
@@ -49,6 +49,7 @@
   },
   "comments": [],
   "media": [],
+  "shapes": [],
   "tables": [],
   "conditionalFormattings": []
 }

--- a/spec/unit/xlsx/xform/sheet/data/sheet.4.0.json
+++ b/spec/unit/xlsx/xform/sheet/data/sheet.4.0.json
@@ -45,6 +45,7 @@
     "B7": { "type": "whole", "allowBlank": true, "showInputMessage": true, "showErrorMessage": true, "operator": "between", "formulae": ["1", "10"]}
   },
   "media": [],
+  "shapes": [],
   "tables": [],
   "conditionalFormattings": [{
     "ref": "A1:E7",

--- a/spec/unit/xlsx/xform/sheet/data/sheet.5.0.json
+++ b/spec/unit/xlsx/xform/sheet/data/sheet.5.0.json
@@ -11,6 +11,7 @@
     }
   ],
   "media": [],
+  "shapes": [],
   "tables": [],
   "conditionalFormattings": []
 }

--- a/spec/unit/xlsx/xform/sheet/data/sheet.7.0.json
+++ b/spec/unit/xlsx/xform/sheet/data/sheet.7.0.json
@@ -44,6 +44,7 @@
     {"id": 5, "max": 2, "min": 0, "man": 1}
   ],
   "media": [],
+  "shapes": [],
   "tables": [],
   "conditionalFormattings": []
 }

--- a/spec/unit/xlsx/xform/sheet/data/sheet.7.1.json
+++ b/spec/unit/xlsx/xform/sheet/data/sheet.7.1.json
@@ -48,6 +48,7 @@
   ],
   "comments": [],
   "media": [],
+  "shapes": [],
   "tables": [],
   "conditionalFormattings": []
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

I created this PR to add basic support of reading/writing shapes and textboxes.
I think this can broaden the use cases of the library, for example, we can load, modify and save existing Excel files including shapes and textboxes without losing them (related issues: #1147, #2086).

I created this PR based on DantSu's https://github.com/exceljs/exceljs/pull/2077, which I think is a great work and highly appreciate.
To help making the PR closer to merge, compared to the DantSu's PR, I did:
- add some unit/integration tests
- add type definitions (index.d.ts)
- change the structure of some models
- resolve conflicts with the current HEAD
- add some functionalities like inner texts, line dashes and alignments

Note that some common functionalities, e.g. scRGB colors, font types and strikethrough styles, are still lacked in this PR.
I'm also willing to add a part to README document.

## Test plan

```js
ws.addShape({
  type: 'roundRect',
  rotation: 15,
  fill: { type: 'solid', color: { rgb: '4499FF' } },
  outline: { weight: 2, color: { rgb: '446699' }, dash: 'sysDash' },
  textBody: {
    vertAlign: 'ctr',
    paragraphs: [
      { alignment: 'l', runs: ["Lorem ipsum dolor sit amet, consectetur adipiscing elit."] },
      { alignment: 'r', runs: [
        { text: "Nulla eget odio sed libero ultrices vehicula.", font: { bold: true, color: { rgb: 'FF0000' } } },
      ] },
    ],
  },
}, 'B2:H8', {
  hyperlink: 'https://www.example.com',
  tooltip: 'Example Link',
});
```

![Screenshot 2023-11-25 at 4 09 47](https://github.com/kigh-ota/exceljs/assets/459628/506e7f43-9694-44b9-863d-0627e3c3ea63)


## Related to source code (for typings update)

<!-- List with permalink into source code to prove that changes are true -->
